### PR TITLE
STORY-884: Model Maintainer can have unit tests for enrich based on transform pipelines

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -64,7 +64,7 @@ steps:
       - cf_export MVN_SET_VERSION="versions:update-property -DnewVersion=[${{RELEASE_NAME}}] -DallowSnapshots=true -DallowDowngrade=true"
 
   BuildTesting:
-    title: Maven build rosetta-testing
+    title: Maven build rune-testing
     stage: 'build'
     fail_fast: false
     image: maven:3.8.5-openjdk-17
@@ -103,9 +103,9 @@ steps:
           isRelease: "${{TAG_REPO}}"
     commands:
       - echo This is a release build, tag repos with release name [${{RELEASE_NAME}}]
-      - git fetch --prune https://${{REGNOSYS_OPS}}:${{REGNOSYS_OPS_TOKEN}}@github.com/REGnosys/${{CF_REPO_NAME}}.git "+refs/tags/*:refs/tags/*"
+      - git fetch --prune https://${{REGNOSYS_OPS}}:${{REGNOSYS_OPS_TOKEN}}@github.com/finos/${{CF_REPO_NAME}}.git "+refs/tags/*:refs/tags/*"
       - git tag ${{RELEASE_NAME}}
-      - git push https://${{REGNOSYS_OPS}}:${{REGNOSYS_OPS_TOKEN}}@github.com/REGnosys/${{CF_REPO_NAME}}.git ${{RELEASE_NAME}}
+      - git push https://${{REGNOSYS_OPS}}:${{REGNOSYS_OPS_TOKEN}}@github.com/finos/${{CF_REPO_NAME}}.git ${{RELEASE_NAME}}
 
   StartNextBuild:
     title: Build rosetta-components if on main

--- a/src/main/java/com/regnosys/testing/pipeline/EvaluateFunctionNotFoundException.java
+++ b/src/main/java/com/regnosys/testing/pipeline/EvaluateFunctionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.regnosys.testing.pipeline;
+
+public class EvaluateFunctionNotFoundException extends RuntimeException{
+    public EvaluateFunctionNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/regnosys/testing/pipeline/EvaluateFunctionNotFoundException.java
+++ b/src/main/java/com/regnosys/testing/pipeline/EvaluateFunctionNotFoundException.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 public class EvaluateFunctionNotFoundException extends RuntimeException{
     public EvaluateFunctionNotFoundException(String message, Throwable cause) {
         super(message, cause);

--- a/src/main/java/com/regnosys/testing/pipeline/FunctionNameHelper.java
+++ b/src/main/java/com/regnosys/testing/pipeline/FunctionNameHelper.java
@@ -62,6 +62,14 @@ public class FunctionNameHelper {
                 .orElse(readableFunctionName(function));
     }
 
+    public String capitalizeFirstLetter(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+        // Capitalize the first letter and concatenate with the rest of the string
+        return input.substring(0, 1).toUpperCase() + input.substring(1);
+    }
+
     protected String readableId(Class<? extends RosettaFunction> function) {
         String simpleName = Optional.ofNullable(function.getAnnotation(RosettaReport.class))
                 .map(a -> String.format("%s-%s", a.body(), String.join("-", a.corpusList())))

--- a/src/main/java/com/regnosys/testing/pipeline/FunctionNameHelper.java
+++ b/src/main/java/com/regnosys/testing/pipeline/FunctionNameHelper.java
@@ -44,24 +44,22 @@ public class FunctionNameHelper {
     }
 
     public Method getFuncMethod(Class<? extends RosettaFunction> function) {
-        List<Method> evaluateMethods = Arrays.stream(function.getMethods())
-                .filter(x -> x.getName().equals("evaluate"))
-                .collect(Collectors.toList());
-        return Iterables.getLast(evaluateMethods);
+        try{
+            List<Method> evaluateMethods = Arrays.stream(function.getMethods())
+                    .filter(x -> x.getName().equals("evaluate"))
+                    .collect(Collectors.toList());
+            return Iterables.getLast(evaluateMethods);
+        }
+        catch(Exception ex) {
+            throw new EvaluateFunctionNotFoundException("evaluate method not found in " + function.getName(), ex);
+        }
+
     }
 
     public String getName(Class<? extends RosettaFunction> function) {
         return Optional.ofNullable(function.getAnnotation(com.rosetta.model.lib.annotations.RosettaReport.class))
                 .map(a -> String.format("%s / %s", a.body(), String.join(" ", a.corpusList())))
                 .orElse(readableFunctionName(function));
-    }
-
-    private String readableFunctionName(Class<? extends RosettaFunction> function) {
-        String readableId = readableId(function);
-
-        return Arrays.stream(readableId.split("-"))
-                .map(s -> s.substring(0, 1).toUpperCase() + s.substring(1))
-                .collect(Collectors.joining(" "));
     }
 
     protected String readableId(Class<? extends RosettaFunction> function) {
@@ -83,6 +81,14 @@ public class FunctionNameHelper {
         return CaseFormat.UPPER_CAMEL
                 .converterTo(CaseFormat.LOWER_HYPHEN)
                 .convert(functionName);
+    }
+
+    private String readableFunctionName(Class<? extends RosettaFunction> function) {
+        String readableId = readableId(function);
+
+        return Arrays.stream(readableId.split("-"))
+                .map(s -> s.substring(0, 1).toUpperCase() + s.substring(1))
+                .collect(Collectors.joining(" "));
     }
 
     private String lowercaseConsecutiveUppercase(String input) {

--- a/src/main/java/com/regnosys/testing/pipeline/FunctionNameHelper.java
+++ b/src/main/java/com/regnosys/testing/pipeline/FunctionNameHelper.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.Iterables;
 import com.rosetta.model.lib.annotations.RosettaReport;
@@ -50,9 +70,10 @@ public class FunctionNameHelper {
                 .orElse(function.getSimpleName());
 
         String sanitise = simpleName
-                .replace("Report", "")
+                .replace("Report_", "")
                 .replace("Function", "")
-                .replace("Project", "")
+                .replace("Enrich_", "")
+                .replace("Project_", "")
                 .replace("-", ".")
                 .replace("_", ".");
 

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineFunctionRunner.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineFunctionRunner.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import com.regnosys.rosetta.common.transform.PipelineModel;

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineFunctionRunner.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineFunctionRunner.java
@@ -41,7 +41,7 @@ public class PipelineFunctionRunner {
 
     public Result run(PipelineModel pipelineModel, ImmutableMap<Class<?>, String> outputSchemaMap, Path inputPath) {
         TestPackFunctionRunner functionRunner = getFunctionRunner(pipelineModel, outputSchemaMap);
-        Pair<String, TestPackModel.SampleModel.Assertions> run = functionRunner.run(inputPath.toAbsolutePath());
+        Pair<String, TestPackModel.SampleModel.Assertions> run = functionRunner.run(inputPath);
         return new Result(run.left(), run.right());
     }
 

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.google.common.collect.ImmutableMap;
 import com.regnosys.rosetta.common.transform.PipelineModel;
 

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
@@ -20,7 +20,6 @@ package com.regnosys.testing.pipeline;
  * ===============
  */
 
-import com.google.common.collect.ImmutableMap;
 import com.regnosys.rosetta.common.transform.PipelineModel;
 
 import javax.inject.Inject;
@@ -42,7 +41,7 @@ public class PipelineModelBuilder {
                 .collect(Collectors.toList());
     }
 
-    public PipelineModel build(PipelineNode modelBuilder, PipelineTreeConfig config) {
+    protected PipelineModel build(PipelineNode modelBuilder, PipelineTreeConfig config) {
 
         String inputType = helper.getInputType(modelBuilder.getFunction());
         String outputType = helper.getOutputType(modelBuilder.getFunction());

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineModelWriter.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineModelWriter.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.regnosys.rosetta.common.transform.PipelineModel;
 import com.regnosys.testing.reports.ObjectMapperGenerator;
@@ -10,6 +30,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PipelineModelWriter {
 
@@ -35,9 +57,24 @@ public class PipelineModelWriter {
         List<PipelineModel> allPipelines = pipelineModelBuilder.createPipelineModels(pipelineTree);
         ObjectWriter objectWriter = ObjectMapperGenerator.createWriterMapper().writerWithDefaultPrettyPrinter();
         for (PipelineModel pipeline : allPipelines) {
+            LOGGER.info("Generating {} pipeline config files for {}", pipeline.getTransform().getType(), pipeline.getName());
             Path writePath = Files.createDirectories(resourcesPath.resolve(pipeline.getTransform().getType().getResourcePath()).resolve("config"));
             Path writeFile = writePath.resolve(pipeline.getId() + ".json");
             objectWriter.writeValue(writeFile.toFile(), pipeline);
         }
+        assertPipelineConfigsCreated(allPipelines, config.getWritePath());
+    }
+
+    private void assertPipelineConfigsCreated(List<PipelineModel> pipelineModels, Path writePath) {
+        pipelineModels.forEach(
+                pipelineModel -> {
+                    final Path pipelineModelPath = writePath.
+                            resolve(pipelineModel.getTransform().getType().getResourcePath()).
+                            resolve("config").
+                            resolve(pipelineModel.getId() + ".json");
+                    assertTrue(Files.exists(pipelineModelPath),
+                            String.format("Error generating config for transform type %s for pipeline %s", pipelineModel.getTransform().getType(), pipelineModel.getName()));
+                }
+        );
     }
 }

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineModelWriter.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineModelWriter.java
@@ -62,19 +62,5 @@ public class PipelineModelWriter {
             Path writeFile = writePath.resolve(pipeline.getId() + ".json");
             objectWriter.writeValue(writeFile.toFile(), pipeline);
         }
-        assertPipelineConfigsCreated(allPipelines, config.getWritePath());
-    }
-
-    private void assertPipelineConfigsCreated(List<PipelineModel> pipelineModels, Path writePath) {
-        pipelineModels.forEach(
-                pipelineModel -> {
-                    final Path pipelineModelPath = writePath.
-                            resolve(pipelineModel.getTransform().getType().getResourcePath()).
-                            resolve("config").
-                            resolve(pipelineModel.getId() + ".json");
-                    assertTrue(Files.exists(pipelineModelPath),
-                            String.format("Error generating config for transform type %s for pipeline %s", pipelineModel.getTransform().getType(), pipelineModel.getName()));
-                }
-        );
     }
 }

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineNode.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineNode.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.regnosys.rosetta.common.transform.TransformType;
 import com.rosetta.model.lib.functions.RosettaFunction;
 

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineNode.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineNode.java
@@ -38,7 +38,7 @@ public class PipelineNode {
         this.transformType = transformType;
     }
 
-    private PipelineNode(FunctionNameHelper functionNameHelper, TransformType transformType, Class<? extends RosettaFunction> function, PipelineNode upstream) {
+    PipelineNode(FunctionNameHelper functionNameHelper, TransformType transformType, Class<? extends RosettaFunction> function, PipelineNode upstream) {
         this.functionNameHelper = functionNameHelper;
         this.transformType = transformType;
         this.function = function;
@@ -101,7 +101,7 @@ public class PipelineNode {
     public String idSuffix(boolean strictUniqueIds, String separator) {
         if (strictUniqueIds) {
             return (upstream == null) ? functionNameHelper.readableId(getFunction()) :
-                    String.format("%s%s%s", upstream.idSuffix(strictUniqueIds, separator), separator, functionNameHelper.readableId(getFunction()));
+                    String.format("%s%s%s", upstream.idSuffix(true, separator), separator, functionNameHelper.readableId(getFunction()));
         }
         return functionNameHelper.readableId(getFunction());
     }

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTestPackWriter.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTestPackWriter.java
@@ -90,7 +90,6 @@ public class PipelineTestPackWriter {
                 objectWriter.writeValue(writeFile.toFile(), testPackModel);
             }
         }
-        assertTestPacksCreated(pipelineTree.getNodeList(), config.getWritePath(), config.isStrictUniqueIds());
     }
 
     private List<Path> inputSamples(Path inputDir) throws IOException {
@@ -139,14 +138,4 @@ public class PipelineTestPackWriter {
         return relativePath.toString().replace(File.pathSeparatorChar, '-');
     }
 
-    private void assertTestPacksCreated(List<PipelineNode> pipelineNodes, Path writePath, boolean strictUniqueIds) {
-        pipelineNodes.forEach(pipelineNode -> assertPipelineTestPackCreated(writePath, pipelineNode, strictUniqueIds));
-    }
-
-    private static void assertPipelineTestPackCreated(Path writePath, PipelineNode pipelineNode, boolean strictUniqueIds) {
-        assertTrue(Files.exists(writePath.resolve(pipelineNode.getInputPath(strictUniqueIds))),
-                String.format("Could not generate %s input sample for %s", pipelineNode.getTransformType(), pipelineNode.getFunction().getName()));
-        assertTrue(Files.exists(writePath.resolve(pipelineNode.getOutputPath(strictUniqueIds))),
-                String.format("Could not generate %s output sample for %s", pipelineNode.getTransformType(), pipelineNode.getFunction().getName()));
-    }
 }

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTestPackWriter.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTestPackWriter.java
@@ -9,9 +9,9 @@ package com.regnosys.testing.pipeline;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,15 +46,12 @@ public class PipelineTestPackWriter {
     private final PipelineModelBuilder pipelineModelBuilder;
     private final PipelineFunctionRunner pipelineFunctionRunner;
 
-    private final FunctionNameHelper helper;
-
 
     @Inject
-    public PipelineTestPackWriter(PipelineTreeBuilder pipelineTreeBuilder, PipelineFunctionRunner pipelineFunctionRunner, PipelineModelBuilder pipelineModelBuilder, FunctionNameHelper helper) {
+    public PipelineTestPackWriter(PipelineTreeBuilder pipelineTreeBuilder, PipelineFunctionRunner pipelineFunctionRunner, PipelineModelBuilder pipelineModelBuilder) {
         this.pipelineTreeBuilder = pipelineTreeBuilder;
         this.pipelineFunctionRunner = pipelineFunctionRunner;
         this.pipelineModelBuilder = pipelineModelBuilder;
-        this.helper = helper;
     }
 
     public void writeTestPacks(PipelineTreeConfig config) throws IOException {
@@ -70,7 +67,7 @@ public class PipelineTestPackWriter {
         PipelineTree pipelineTree = pipelineTreeBuilder.createPipelineTree(config);
 
         for (PipelineNode pipelineNode : pipelineTree.getNodeList()) {
-            LOGGER.info("Generating {} test packs for {} ", pipelineNode.getTransformType(), pipelineNode.getFunction().getName());
+            LOGGER.info("Generating {} Test Packs for {} ", pipelineNode.getTransformType(), pipelineNode.getFunction().getName());
 
             Path inputPath = resourcesPath.resolve(pipelineNode.getInputPath(config.isStrictUniqueIds()));
             LOGGER.info("Input path {} ", inputPath);
@@ -81,7 +78,7 @@ public class PipelineTestPackWriter {
             List<Path> inputSamples = inputSamples(inputPath);
 
             Map<String, List<Path>> testPackToSamples = groupingByTestPackId(resourcesPath, inputPath, inputSamples);
-            LOGGER.info("{} Test packs will be generated", testPackToSamples.keySet().size());
+            LOGGER.info("{} Test Packs will be generated", testPackToSamples.keySet().size());
 
             for (String testPackId : testPackToSamples.keySet()) {
                 List<Path> inputSamplesForTestPack = testPackToSamples.get(testPackId);
@@ -105,8 +102,8 @@ public class PipelineTestPackWriter {
     }
 
     private TestPackModel writeTestPackSamples(Path resourcesPath, Path inputPath, Path outputDir, String testPackId, List<Path> inputSamplesForTestPack, PipelineNode pipelineNode, PipelineTreeConfig config) throws IOException {
-        LOGGER.info("Test pack sample generation started for {}",  testPackId);
-        LOGGER.info("{} samples to be generated",  inputSamplesForTestPack.size());
+        LOGGER.info("Test pack sample generation started for {}", testPackId);
+        LOGGER.info("{} samples to be generated", inputSamplesForTestPack.size());
         List<TestPackModel.SampleModel> sampleModels = new ArrayList<>();
         String pipelineId = pipelineNode.id(config.isStrictUniqueIds());
         String pipelineIdSuffix = pipelineNode.idSuffix(config.isStrictUniqueIds(), "-");
@@ -125,7 +122,7 @@ public class PipelineTestPackWriter {
             Files.createDirectories(resourcesPath.resolve(outputSample).getParent());
             Files.write(resourcesPath.resolve(outputSample), run.getSerialisedOutput().getBytes());
         }
-        LOGGER.info("Test pack sample generation complete for {} ", testPackId);
+        LOGGER.info("Test Pack sample generation complete for {} ", testPackId);
         String testPackName = testPackId.replace("-", " ");
         return new TestPackModel(String.format("test-pack-%s-%s-%s", pipelineNode.getTransformType().name().toLowerCase(), pipelineIdSuffix, testPackId), pipelineId, testPackName, sampleModels);
     }

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTree.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTree.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import java.util.List;
 
 public class PipelineTree {

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTreeBuilder.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTreeBuilder.java
@@ -9,9 +9,9 @@ package com.regnosys.testing.pipeline;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,13 +43,20 @@ public class PipelineTreeBuilder {
     }
 
     public PipelineTree createPipelineTree(PipelineTreeConfig pipelineTreeConfig) {
-        List<PipelineTreeConfig.TransformFunction> starting = pipelineTreeConfig.getStarting();
-        List<PipelineNode> nodeList = starting.stream()
-                .map(t -> downstreamPipelines(pipelineTreeConfig, new PipelineNode(helper, t.getTransformType()).withFunction(t.getFunction())))
-                .flatMap(Collection::stream)
-                .sorted(Comparator.comparing(PipelineNode::getTransformType))
-                .collect(Collectors.toList());
-        return new PipelineTree(nodeList, pipelineTreeConfig);
+        try {
+            List<PipelineTreeConfig.TransformFunction> starting = pipelineTreeConfig.getStarting();
+            List<PipelineNode> nodeList = starting.stream()
+                    .map(t -> downstreamPipelines(pipelineTreeConfig, new PipelineNode(helper, t.getTransformType()).withFunction(t.getFunction())))
+                    .flatMap(Collection::stream)
+                    .sorted(Comparator.comparing(PipelineNode::getTransformType))
+                    .collect(Collectors.toList());
+            return new PipelineTree(nodeList, pipelineTreeConfig);
+        }
+        catch (Exception ex){
+            throw new PipelineTreeCreationException("could not create pipeline tree", ex);
+        }
+
+
     }
 
 

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTreeBuilder.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTreeBuilder.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.regnosys.rosetta.common.transform.TransformType;
 import com.rosetta.model.lib.functions.RosettaFunction;
 import org.slf4j.Logger;

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTreeConfig.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTreeConfig.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTreeCreationException.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTreeCreationException.java
@@ -1,0 +1,7 @@
+package com.regnosys.testing.pipeline;
+
+public class PipelineTreeCreationException extends RuntimeException {
+    public PipelineTreeCreationException(String message, Exception ex) {
+        super(message, ex);
+    }
+}

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTreeCreationException.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTreeCreationException.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 public class PipelineTreeCreationException extends RuntimeException {
     public PipelineTreeCreationException(String message, Exception ex) {
         super(message, ex);

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
@@ -78,9 +78,7 @@ public class TestPackFunctionRunnerImpl<IN extends RosettaModelObject> implement
     public Pair<String, Assertions> run(Path inputPath) {
         RosettaModelObject output;
         try {
-            // TODO - fix this hack.
-            Path inputPathFromRepositoryRoot = inputPath.isAbsolute() ? inputPath : ROSETTA_SOURCE_PATH.resolve(inputPath);
-            URL inputFileUrl = inputPathFromRepositoryRoot.toUri().toURL();
+            URL inputFileUrl = inputPath.toUri().toURL();
             IN input = readFile(inputFileUrl, JSON_OBJECT_MAPPER, inputType);
             output = function.apply(resolveReferences(input));
         } catch (MalformedURLException e) {

--- a/src/test/java/com/regnosys/testing/pipeline/FunctionNameHelperTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/FunctionNameHelperTest.java
@@ -20,10 +20,7 @@ package com.regnosys.testing.pipeline;
  * ===============
  */
 
-import com.rosetta.model.lib.functions.RosettaFunction;
 import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -62,6 +59,21 @@ class FunctionNameHelperTest {
     }
 
     @Test
+    void getNameEnrich() {
+        assertEquals("Type1 To Type2", functionNameHelper.getName(PipelineTestUtils.Enrich_Type_1ToType_2.class));
+    }
+
+    @Test
+    void getNameReport() {
+        assertEquals("Type2 To Type3", functionNameHelper.getName(PipelineTestUtils.Report_Type_2ToType_3.class));
+    }
+
+    @Test
+    void getNameProjection() {
+        assertEquals("Type3 To Type4", functionNameHelper.getName(PipelineTestUtils.Project_Type_3ToType_4.class));
+    }
+
+    @Test
     void readableIdEnrich() {
         assertEquals("type1-to-type2", functionNameHelper.readableId(PipelineTestUtils.Enrich_Type_1ToType_2.class));
     }
@@ -73,6 +85,16 @@ class FunctionNameHelperTest {
 
     @Test
     void readableIdProjection() {
-        assertEquals("projection-type3-to-type4", functionNameHelper.readableId(PipelineTestUtils.Projection_Type_3ToType_4.class));
+        assertEquals("type3-to-type4", functionNameHelper.readableId(PipelineTestUtils.Project_Type_3ToType_4.class));
+    }
+
+    @Test
+    void readableIdAllUpperCase() {
+        assertEquals("type2-to-type3", functionNameHelper.readableId(PipelineTestUtils.Report_TYPE_2_TO_TYPE_3.class));
+    }
+
+    @Test
+    void nameAllUpperCase() {
+        assertEquals("Type2 To Type3", functionNameHelper.getName(PipelineTestUtils.Report_TYPE_2_TO_TYPE_3.class));
     }
 }

--- a/src/test/java/com/regnosys/testing/pipeline/FunctionNameHelperTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/FunctionNameHelperTest.java
@@ -9,9 +9,9 @@ package com.regnosys.testing.pipeline;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,8 @@ package com.regnosys.testing.pipeline;
 import com.rosetta.model.lib.functions.RosettaFunction;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class FunctionNameHelperTest {
@@ -30,20 +32,47 @@ class FunctionNameHelperTest {
     private final FunctionNameHelper functionNameHelper = new FunctionNameHelper();
 
     @Test
-    void readableId() {
-        assertEquals("asic-trade-to-iso20022", functionNameHelper.readableId(Project_ASICTradeReportToIso20022.class));
+    void getInputType() {
+        assertEquals("com.rosetta.model.lib.RosettaModelObject", functionNameHelper.getInputType(PipelineTestUtils.Enrich_Type_1ToType_2.class));
+    }
+
+    @Test
+    void getOutputType() {
+        assertEquals("java.lang.String", functionNameHelper.getOutputType(PipelineTestUtils.Enrich_Type_1ToType_2.class));
+    }
+
+    @Test
+    void getFuncMethod() {
+        assertEquals("evaluate", functionNameHelper.getFuncMethod(PipelineTestUtils.Enrich_Type_1ToType_2.class).getName());
+    }
+
+    @Test
+    void getInputTypeNoEvaluate() {
+        assertThrows(EvaluateFunctionNotFoundException.class,  () -> functionNameHelper.getInputType(PipelineTestUtils.Report_Type_2ToType_3.class));
+    }
+
+    @Test
+    void getOutputTypeNoEvaluate() {
+        assertThrows(EvaluateFunctionNotFoundException.class,  () -> functionNameHelper.getOutputType(PipelineTestUtils.Report_Type_2ToType_3.class));
+    }
+
+    @Test
+    void getFuncMethodNoEvaluate() {
+        assertThrows(EvaluateFunctionNotFoundException.class,  () -> functionNameHelper.getFuncMethod(PipelineTestUtils.Report_Type_2ToType_3.class));
     }
 
     @Test
     void readableIdEnrich() {
-        assertEquals("asic-trade-to-iso20022", functionNameHelper.readableId(Enrich_ReportableEventToTransactionReportInstruction.class));
+        assertEquals("type1-to-type2", functionNameHelper.readableId(PipelineTestUtils.Enrich_Type_1ToType_2.class));
     }
 
-    static class Project_ASICTradeReportToIso20022 implements RosettaFunction {
-
+    @Test
+    void readableIdReport() {
+        assertEquals("type2-to-type3", functionNameHelper.readableId(PipelineTestUtils.Report_Type_2ToType_3.class));
     }
 
-    static class Enrich_ReportableEventToTransactionReportInstruction implements RosettaFunction {
-
+    @Test
+    void readableIdProjection() {
+        assertEquals("projection-type3-to-type4", functionNameHelper.readableId(PipelineTestUtils.Projection_Type_3ToType_4.class));
     }
 }

--- a/src/test/java/com/regnosys/testing/pipeline/FunctionNameHelperTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/FunctionNameHelperTest.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.rosetta.model.lib.functions.RosettaFunction;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +34,16 @@ class FunctionNameHelperTest {
         assertEquals("asic-trade-to-iso20022", functionNameHelper.readableId(Project_ASICTradeReportToIso20022.class));
     }
 
+    @Test
+    void readableIdEnrich() {
+        assertEquals("asic-trade-to-iso20022", functionNameHelper.readableId(Enrich_ReportableEventToTransactionReportInstruction.class));
+    }
+
     static class Project_ASICTradeReportToIso20022 implements RosettaFunction {
+
+    }
+
+    static class Enrich_ReportableEventToTransactionReportInstruction implements RosettaFunction {
 
     }
 }

--- a/src/test/java/com/regnosys/testing/pipeline/FunctionNameHelperTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/FunctionNameHelperTest.java
@@ -97,4 +97,19 @@ class FunctionNameHelperTest {
     void nameAllUpperCase() {
         assertEquals("Type2 To Type3", functionNameHelper.getName(PipelineTestUtils.Report_TYPE_2_TO_TYPE_3.class));
     }
+
+    @Test
+    void getNameFromId() {
+        assertEquals("Test Pack id", functionNameHelper.capitalizeFirstLetter("test Pack id"));
+    }
+
+    @Test
+    void getNameFromIdAllCaps() {
+        assertEquals("TESTPACKID", functionNameHelper.capitalizeFirstLetter("TESTPACKID"));
+    }
+
+    @Test
+    void getNameFromIdAllLowerCase() {
+        assertEquals("Test-pack-id", functionNameHelper.capitalizeFirstLetter("test-pack-id"));
+    }
 }

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineModelBuilderTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineModelBuilderTest.java
@@ -1,0 +1,212 @@
+package com.regnosys.testing.pipeline;
+
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
+import com.regnosys.rosetta.common.transform.PipelineModel;
+import com.regnosys.rosetta.common.transform.TransformType;
+import com.rosetta.model.lib.functions.RosettaFunction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.Iterables.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.runners.model.MultipleFailureException.assertEmpty;
+
+class PipelineModelBuilderTest {
+
+    @Inject
+    private PipelineTreeBuilder pipelineTreeBuilder;
+
+    @Inject
+    private PipelineModelBuilder pipelineModelBuilder;
+
+    @Inject
+    PipelineTestHelper helper;
+
+    @BeforeEach
+    void setUp() {
+        PipelineTestHelper.setupInjector(this);
+    }
+
+    @Test
+    void buildChain() {
+        PipelineTree pipelineTree = pipelineTreeBuilder.createPipelineTree(helper.createTreeConfig());
+        List<PipelineModel> pipelineModels = pipelineModelBuilder.createPipelineModels(pipelineTree);
+
+        Map<TransformType, List<PipelineModel>> byTransformType = pipelineModels.stream().collect(Collectors.groupingBy(x -> x.getTransform().getType()));
+
+        PipelineModel startPipeline = getOnlyElement(byTransformType.get(TransformType.ENRICH));
+        PipelineModel middlePipeline = getOnlyElement(byTransformType.get(TransformType.REPORT));
+        PipelineModel endPipeline = getOnlyElement(byTransformType.get(TransformType.PROJECTION));
+
+        assertPipelineModel(startPipeline, TransformType.ENRICH, helper.startClass(), "pipeline-enrich-start", null);
+        assertPipelineModel(middlePipeline, TransformType.REPORT, helper.middleClass(), "pipeline-report-middle", "pipeline-enrich-start");
+        assertPipelineModel(endPipeline, TransformType.PROJECTION, helper.endClass(), "pipeline-projection-end", "pipeline-report-middle");
+    }
+
+
+    @Test
+    void buildChainWithUniqueIds() {
+        PipelineTree pipelineTree = pipelineTreeBuilder.createPipelineTree(helper.createTreeConfig().strictUniqueIds());
+        List<PipelineModel> pipelineModels = pipelineModelBuilder.createPipelineModels(pipelineTree);
+
+        Map<TransformType, List<PipelineModel>> byTransformType = pipelineModels.stream().collect(Collectors.groupingBy(x -> x.getTransform().getType()));
+
+        PipelineModel startPipeline = getOnlyElement(byTransformType.get(TransformType.ENRICH));
+        PipelineModel middlePipeline = getOnlyElement(byTransformType.get(TransformType.REPORT));
+        PipelineModel endPipeline = getOnlyElement(byTransformType.get(TransformType.PROJECTION));
+
+        assertPipelineModel(startPipeline, TransformType.ENRICH, helper.startClass(), "pipeline-enrich-start", null);
+        assertPipelineModel(middlePipeline, TransformType.REPORT, helper.middleClass(), "pipeline-report-start-middle", "pipeline-enrich-start");
+        assertPipelineModel(endPipeline, TransformType.PROJECTION, helper.endClass(), "pipeline-projection-start-middle-end", "pipeline-report-start-middle");
+    }
+
+    @Test
+    void buildChainWithoutUniqueIds() {
+        PipelineTree pipelineTree = pipelineTreeBuilder.createPipelineTree(helper.createTreeConfig());
+        List<PipelineModel> pipelineModels = pipelineModelBuilder.createPipelineModels(pipelineTree);
+
+        Map<TransformType, List<PipelineModel>> byTransformType = pipelineModels.stream().collect(Collectors.groupingBy(x -> x.getTransform().getType()));
+
+        PipelineModel startPipeline = getOnlyElement(byTransformType.get(TransformType.ENRICH));
+        PipelineModel middlePipeline = getOnlyElement(byTransformType.get(TransformType.REPORT));
+        PipelineModel endPipeline = getOnlyElement(byTransformType.get(TransformType.PROJECTION));
+
+        assertPipelineModel(startPipeline, TransformType.ENRICH, helper.startClass(), "pipeline-enrich-start", null);
+        assertPipelineModel(middlePipeline, TransformType.REPORT, helper.middleClass(), "pipeline-report-middle", "pipeline-enrich-start");
+        assertPipelineModel(endPipeline, TransformType.PROJECTION, helper.endClass(), "pipeline-projection-end", "pipeline-report-middle");
+    }
+
+
+    @Test
+    void buildNestedChainWithUniqueIds() {
+        PipelineTree pipelineTree = pipelineTreeBuilder.createPipelineTree(helper.createNestedTreeConfig().strictUniqueIds());
+        List<PipelineModel> pipelineModels = pipelineModelBuilder.createPipelineModels(pipelineTree);
+
+        Map<TransformType, List<PipelineModel>> byTransformType = pipelineModels.stream().collect(Collectors.groupingBy(x -> x.getTransform().getType()));
+
+        PipelineModel startPipeline = getOnlyElement(byTransformType.get(TransformType.ENRICH));
+        List<PipelineModel> middlePipelines = byTransformType.get(TransformType.REPORT);
+        assertEquals(2, middlePipelines.size());
+
+        List<PipelineModel> endPipelines = byTransformType.get(TransformType.PROJECTION);
+        assertEquals(4, endPipelines.size());
+
+        assertPipelineModel(startPipeline, TransformType.ENRICH, helper.startClass(), "pipeline-enrich-start", null);
+
+        assertPipelineModel(middlePipelines.get(0), TransformType.REPORT, helper.middleAClass(), "pipeline-report-start-middle-a", "pipeline-enrich-start");
+        assertPipelineModel(middlePipelines.get(1), TransformType.REPORT, helper.middleBClass(), "pipeline-report-start-middle-b", "pipeline-enrich-start");
+
+        assertPipelineModel(endPipelines.get(0), TransformType.PROJECTION, helper.endAClass(), "pipeline-projection-start-middle-a-end-a", "pipeline-report-start-middle-a");
+        assertPipelineModel(endPipelines.get(1), TransformType.PROJECTION, helper.endBClass(), "pipeline-projection-start-middle-a-end-b", "pipeline-report-start-middle-a");
+        assertPipelineModel(endPipelines.get(2), TransformType.PROJECTION, helper.endAClass(), "pipeline-projection-start-middle-b-end-a", "pipeline-report-start-middle-b");
+        assertPipelineModel(endPipelines.get(3), TransformType.PROJECTION, helper.endBClass(), "pipeline-projection-start-middle-b-end-b", "pipeline-report-start-middle-b");
+    }
+
+    @Test
+    void buildNestedChainWithoutUniqueIds() {
+        PipelineTree pipelineTree = pipelineTreeBuilder.createPipelineTree(helper.createNestedTreeConfig());
+        List<PipelineModel> pipelineModels = pipelineModelBuilder.createPipelineModels(pipelineTree);
+
+        Map<TransformType, List<PipelineModel>> byTransformType = pipelineModels.stream().collect(Collectors.groupingBy(x -> x.getTransform().getType()));
+
+        PipelineModel startPipeline = getOnlyElement(byTransformType.get(TransformType.ENRICH));
+        List<PipelineModel> middlePipelines = byTransformType.get(TransformType.REPORT);
+        assertEquals(2, middlePipelines.size());
+
+        List<PipelineModel> endPipelines = byTransformType.get(TransformType.PROJECTION);
+        assertEquals(4, endPipelines.size());
+
+        assertPipelineModel(startPipeline, TransformType.ENRICH, helper.startClass(), "pipeline-enrich-start", null);
+
+        assertPipelineModel(middlePipelines.get(0), TransformType.REPORT, helper.middleAClass(), "pipeline-report-middle-a", "pipeline-enrich-start");
+        assertPipelineModel(middlePipelines.get(1), TransformType.REPORT, helper.middleBClass(), "pipeline-report-middle-b", "pipeline-enrich-start");
+
+        assertPipelineModel(endPipelines.get(0), TransformType.PROJECTION, helper.endAClass(), "pipeline-projection-end-a", "pipeline-report-middle-a");
+        assertPipelineModel(endPipelines.get(1), TransformType.PROJECTION, helper.endBClass(), "pipeline-projection-end-b", "pipeline-report-middle-a");
+        assertPipelineModel(endPipelines.get(2), TransformType.PROJECTION, helper.endAClass(), "pipeline-projection-end-a", "pipeline-report-middle-b");
+        assertPipelineModel(endPipelines.get(3), TransformType.PROJECTION, helper.endBClass(), "pipeline-projection-end-b", "pipeline-report-middle-b");
+    }
+
+    @Test
+    void buildNestedChainWithMultipleStartNodesWithUniqueIds() {
+        PipelineTree pipelineTree = pipelineTreeBuilder.createPipelineTree(helper.createNestedTreeConfigMultipleStartingNodes().strictUniqueIds());
+        List<PipelineModel> pipelineModels = pipelineModelBuilder.createPipelineModels(pipelineTree);
+
+        Map<TransformType, List<PipelineModel>> byTransformType = pipelineModels.stream().collect(Collectors.groupingBy(x -> x.getTransform().getType()));
+
+        List<PipelineModel> middlePipelines = byTransformType.get(TransformType.REPORT);
+        assertEquals(2, middlePipelines.size());
+
+        List<PipelineModel> endPipelines = byTransformType.get(TransformType.PROJECTION);
+        assertEquals(4, endPipelines.size());
+
+        assertPipelineModel(middlePipelines.get(0), TransformType.REPORT, helper.middleAClass(), "pipeline-report-middle-a", null);
+        assertPipelineModel(middlePipelines.get(1), TransformType.REPORT, helper.middleBClass(), "pipeline-report-middle-b", null);
+
+        assertPipelineModel(endPipelines.get(0), TransformType.PROJECTION, helper.endAClass(), "pipeline-projection-middle-a-end-a", "pipeline-report-middle-a");
+        assertPipelineModel(endPipelines.get(1), TransformType.PROJECTION, helper.endBClass(), "pipeline-projection-middle-a-end-b", "pipeline-report-middle-a");
+        assertPipelineModel(endPipelines.get(2), TransformType.PROJECTION, helper.endAClass(), "pipeline-projection-middle-b-end-a", "pipeline-report-middle-b");
+        assertPipelineModel(endPipelines.get(3), TransformType.PROJECTION, helper.endBClass(), "pipeline-projection-middle-b-end-b", "pipeline-report-middle-b");
+    }
+
+    @Test
+    void buildNestedChainWithMultipleStartNodesWithoutUniqueIds() {
+        PipelineTree pipelineTree = pipelineTreeBuilder.createPipelineTree(helper.createNestedTreeConfigMultipleStartingNodes());
+        List<PipelineModel> pipelineModels = pipelineModelBuilder.createPipelineModels(pipelineTree);
+
+        Map<TransformType, List<PipelineModel>> byTransformType = pipelineModels.stream().collect(Collectors.groupingBy(x -> x.getTransform().getType()));
+
+        List<PipelineModel> middlePipelines = byTransformType.get(TransformType.REPORT);
+        assertEquals(2, middlePipelines.size());
+
+        List<PipelineModel> endPipelines = byTransformType.get(TransformType.PROJECTION);
+        assertEquals(4, endPipelines.size());
+
+        assertPipelineModel(middlePipelines.get(0), TransformType.REPORT, helper.middleAClass(), "pipeline-report-middle-a", null);
+        assertPipelineModel(middlePipelines.get(1), TransformType.REPORT, helper.middleBClass(), "pipeline-report-middle-b", null);
+
+        assertPipelineModel(endPipelines.get(0), TransformType.PROJECTION, helper.endAClass(), "pipeline-projection-end-a", "pipeline-report-middle-a");
+        assertPipelineModel(endPipelines.get(1), TransformType.PROJECTION, helper.endBClass(), "pipeline-projection-end-b", "pipeline-report-middle-a");
+        assertPipelineModel(endPipelines.get(2), TransformType.PROJECTION, helper.endAClass(), "pipeline-projection-end-a", "pipeline-report-middle-b");
+        assertPipelineModel(endPipelines.get(3), TransformType.PROJECTION, helper.endBClass(), "pipeline-projection-end-b", "pipeline-report-middle-b");
+    }
+
+    @Test
+    void buildNestedChainWithoutStarting() {
+        PipelineTree pipelineTree = pipelineTreeBuilder.createPipelineTree(helper.createTreeConfigWithoutStarting().strictUniqueIds());
+        List<PipelineModel> pipelineModels = pipelineModelBuilder.createPipelineModels(pipelineTree);
+        assertTrue(isEmpty(pipelineTree.getNodeList()));
+        assertTrue(isEmpty(pipelineModels));
+    }
+
+    private static void assertPipelineModel(PipelineModel pipelineModel, TransformType transformType, Class<? extends RosettaFunction> function, String pipelineId, String upstreamPipelineId) {
+        assertEquals(transformType, pipelineModel.getTransform().getType(), "Wrong transform type");
+        assertEquals(function.getName(), pipelineModel.getTransform().getFunction(), "Wrong function name");
+        assertEquals(pipelineId, pipelineModel.getId(), "Wrong pipeline id");
+        assertEquals(upstreamPipelineId, pipelineModel.getUpstreamPipelineId(), "Wrong upstream pipeline id");
+    }
+}

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineModelWriterTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineModelWriterTest.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.regnosys.rosetta.common.transform.TransformType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineNodeTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineNodeTest.java
@@ -1,8 +1,6 @@
 package com.regnosys.testing.pipeline;
 
 import com.regnosys.rosetta.common.transform.TransformType;
-import com.rosetta.model.lib.RosettaModelObject;
-import com.rosetta.model.lib.functions.RosettaFunction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +28,7 @@ class PipelineNodeTest {
         PipelineTestHelper.setupInjector(this);
         ENRICH_NODE = new PipelineNode(functionNameHelper, TransformType.ENRICH, PipelineTestUtils.Enrich_Type_1ToType_2.class, null);
         REPORT_NODE = new PipelineNode(functionNameHelper, TransformType.REPORT, PipelineTestUtils.Report_Type_2ToType_3.class, ENRICH_NODE);
-        PROJECTION_NODE = new PipelineNode(functionNameHelper, TransformType.PROJECTION, PipelineTestUtils.Projection_Type_3ToType_4.class, REPORT_NODE);
+        PROJECTION_NODE = new PipelineNode(functionNameHelper, TransformType.PROJECTION, PipelineTestUtils.Project_Type_3ToType_4.class, REPORT_NODE);
     }
 
     @Test

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineNodeTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineNodeTest.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.regnosys.rosetta.common.transform.TransformType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,11 +88,11 @@ class PipelineNodeTest {
 
     @Test
     void idSuffixChildNode() {
-        assertEquals("type1-to-type2-type2-to-type3-projection-type3-to-type4", PROJECTION_NODE.idSuffix(STRICT_IDS, "-"));
+        assertEquals("type1-to-type2-type2-to-type3-type3-to-type4", PROJECTION_NODE.idSuffix(STRICT_IDS, "-"));
     }
 
     @Test
     void idSuffixWithoutStrictIdsChildNode() {
-        assertEquals("projection-type3-to-type4", PROJECTION_NODE.idSuffix(NO_STRICT_IDs, "-"));
+        assertEquals("type3-to-type4", PROJECTION_NODE.idSuffix(NO_STRICT_IDs, "-"));
     }
 }

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineNodeTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineNodeTest.java
@@ -1,0 +1,80 @@
+package com.regnosys.testing.pipeline;
+
+import com.regnosys.rosetta.common.transform.TransformType;
+import com.rosetta.model.lib.RosettaModelObject;
+import com.rosetta.model.lib.functions.RosettaFunction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PipelineNodeTest {
+
+    @Inject
+    private FunctionNameHelper functionNameHelper;
+
+    private static PipelineNode ENRICH_NODE;
+
+    private static PipelineNode REPORT_NODE;
+
+    private static PipelineNode PROJECTION_NODE;
+
+    private static final boolean STRICT_IDS = true;
+
+    private static final boolean NO_STRICT_IDs = false;
+
+    @BeforeEach
+    void setUp() {
+        PipelineTestHelper.setupInjector(this);
+        ENRICH_NODE = new PipelineNode(functionNameHelper, TransformType.ENRICH, PipelineTestUtils.Enrich_Type_1ToType_2.class, null);
+        REPORT_NODE = new PipelineNode(functionNameHelper, TransformType.REPORT, PipelineTestUtils.Report_Type_2ToType_3.class, ENRICH_NODE);
+        PROJECTION_NODE = new PipelineNode(functionNameHelper, TransformType.PROJECTION, PipelineTestUtils.Projection_Type_3ToType_4.class, REPORT_NODE);
+    }
+
+    @Test
+    void id() {
+        assertEquals("pipeline-enrich-type1-to-type2", ENRICH_NODE.id(STRICT_IDS));
+    }
+
+    @Test
+    void idWithoutStrictIds() {
+        assertEquals("pipeline-enrich-type1-to-type2", ENRICH_NODE.id(NO_STRICT_IDs));
+    }
+
+    @Test
+    void nullUpstream() {
+        assertNull(ENRICH_NODE.upstreamId(STRICT_IDS));
+    }
+
+    @Test
+    void upstreamId() {
+        assertEquals("pipeline-report-type1-to-type2-type2-to-type3", PROJECTION_NODE.upstreamId(STRICT_IDS));
+    }
+
+    @Test
+    void upstreamIdWithoutStrictIds() {
+        assertEquals("pipeline-report-type2-to-type3", PROJECTION_NODE.upstreamId(NO_STRICT_IDs));
+    }
+
+    @Test
+    void idSuffixParentNode() {
+        assertEquals("type1-to-type2", ENRICH_NODE.idSuffix(STRICT_IDS, "-"));
+    }
+
+    @Test
+    void idSuffixWithoutStrictIdsParentNode() {
+        assertEquals("type1-to-type2", ENRICH_NODE.idSuffix(STRICT_IDS, "-"));
+    }
+
+    @Test
+    void idSuffixChildNode() {
+        assertEquals("type1-to-type2-type2-to-type3-projection-type3-to-type4", PROJECTION_NODE.idSuffix(STRICT_IDS, "-"));
+    }
+
+    @Test
+    void idSuffixWithoutStrictIdsChildNode() {
+        assertEquals("projection-type3-to-type4", PROJECTION_NODE.idSuffix(NO_STRICT_IDs, "-"));
+    }
+}

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineTestHelper.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineTestHelper.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.regnosys.rosetta.common.hashing.ReferenceConfig;

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineTestHelper.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineTestHelper.java
@@ -120,6 +120,23 @@ public class PipelineTestHelper {
                 .add(middleClass(), TransformType.PROJECTION, endClass());
     }
 
+    PipelineTreeConfig createNestedTreeConfigMultipleStartingNodes() {
+        return new PipelineTreeConfig()
+                .starting(TransformType.REPORT, middleAClass())
+                .add(middleAClass(), TransformType.PROJECTION, endAClass())
+                .add(middleAClass(), TransformType.PROJECTION, endBClass())
+
+                .starting(TransformType.REPORT, middleBClass())
+                .add(middleBClass(), TransformType.PROJECTION, endAClass())
+                .add(middleBClass(), TransformType.PROJECTION, endBClass());
+    }
+
+    PipelineTreeConfig createTreeConfigWithoutStarting() {
+        return new PipelineTreeConfig()
+                .add(startClass(), TransformType.REPORT, middleClass())
+                .add(middleClass(), TransformType.PROJECTION, endClass());
+    }
+
     private CompiledCode compileCode() throws Exception {
         CompiledCode compiledCode = modelHelper.generateAndCompileJava(Files.readString(testPath.resolve("rosetta/pipelines.rosetta")));
 

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineTestPackWriterTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineTestPackWriterTest.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.regnosys.rosetta.common.transform.TransformType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineTestPackWriterTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineTestPackWriterTest.java
@@ -46,7 +46,7 @@ public class PipelineTestPackWriterTest {
     }
 
     @Test
-    void writeTestPacks(@TempDir Path tempDir) throws Exception {
+    void writeTestPacksForNestedTreeConfig(@TempDir Path tempDir) throws Exception {
         Path inputPath = Files.createDirectories(tempDir.resolve(TransformType.ENRICH.getResourcePath()).resolve("input"));
 
         Path testPack1Path = Files.createDirectories(inputPath.resolve("test-pack-1"));
@@ -102,6 +102,113 @@ public class PipelineTestPackWriterTest {
         assertFileExists(tempDir, "projection/output/start/middle-a/end-b/test-pack-2/sample-2-1.json");
         assertFileExists(tempDir, "projection/output/start/middle-a/end-b/test-pack-1/sample-1-1.json");
         assertFileExists(tempDir, "projection/output/start/middle-a/end-b/test-pack-1/sample-1-2.json");
+    }
+
+    @Test
+    void writeTestPacksForTreeConfig(@TempDir Path tempDir) throws Exception {
+        Path inputPath = Files.createDirectories(tempDir.resolve(TransformType.ENRICH.getResourcePath()).resolve("input"));
+
+        Path testPack1Path = Files.createDirectories(inputPath.resolve("test-pack-1"));
+        Path testPack2Path = Files.createDirectories(inputPath.resolve("test-pack-2"));
+
+        Files.write(testPack1Path.resolve("sample-1-1.json"), "{\"name\": \"1-1\"}".getBytes());
+        Files.write(testPack1Path.resolve("sample-1-2.json"), "{\"name\": \"1-2\"}".getBytes());
+        Files.write(testPack2Path.resolve("sample-2-1.json"), "{\"name\": \"2-1\"}".getBytes());
+        Files.write(testPack2Path.resolve("sample-2-2.json"), "{\"name\": \"2-2\"}".getBytes());
+
+        PipelineTreeConfig chain = helper.createTreeConfig().strictUniqueIds().withWritePath(tempDir);
+        pipelineTestPackWriter.writeTestPacks(chain);
+
+
+        assertFileExists(tempDir, "enrich/config/test-pack-enrich-start-test-pack-1.json");
+        assertFileExists(tempDir, "enrich/config/test-pack-enrich-start-test-pack-2.json");
+        assertFileExists(tempDir, "regulatory-reporting/config/test-pack-report-start-middle-test-pack-1.json");
+        assertFileExists(tempDir, "regulatory-reporting/config/test-pack-report-start-middle-test-pack-2.json");
+        assertFileExists(tempDir, "projection/config/test-pack-projection-start-middle-end-test-pack-1.json");
+        assertFileExists(tempDir, "projection/config/test-pack-projection-start-middle-end-test-pack-2.json");
+
+        assertFileExists(tempDir, "regulatory-reporting/output/start/middle/test-pack-2/sample-2-2.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/start/middle/test-pack-2/sample-2-1.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/start/middle/test-pack-1/sample-1-1.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/start/middle/test-pack-1/sample-1-2.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/start/middle/test-pack-2/sample-2-2.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/start/middle/test-pack-2/sample-2-1.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/start/middle/test-pack-1/sample-1-1.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/start/middle/test-pack-1/sample-1-2.json");
+        assertFileExists(tempDir, "enrich/output/start/test-pack-2/sample-2-2.json");
+        assertFileExists(tempDir, "enrich/output/start/test-pack-2/sample-2-1.json");
+        assertFileExists(tempDir, "enrich/output/start/test-pack-1/sample-1-1.json");
+        assertFileExists(tempDir, "enrich/output/start/test-pack-1/sample-1-2.json");
+
+        assertFileExists(tempDir, "projection/output/start/middle/end/test-pack-2/sample-2-2.json");
+        assertFileExists(tempDir, "projection/output/start/middle/end/test-pack-2/sample-2-1.json");
+        assertFileExists(tempDir, "projection/output/start/middle/end/test-pack-1/sample-1-1.json");
+        assertFileExists(tempDir, "projection/output/start/middle/end/test-pack-1/sample-1-2.json");
+
+    }
+
+    @Test
+    void writeTestPacksForTreeConfigWithMultipleStartNodes(@TempDir Path tempDir) throws Exception {
+        Path inputPath = Files.createDirectories(tempDir.resolve(TransformType.REPORT.getResourcePath()).resolve("input"));
+
+        Path testPack1Path = Files.createDirectories(inputPath.resolve("test-pack-1"));
+        Path testPack2Path = Files.createDirectories(inputPath.resolve("test-pack-2"));
+
+        Files.write(testPack1Path.resolve("sample-1-1.json"), "{\"name\": \"1-1\"}".getBytes());
+        Files.write(testPack1Path.resolve("sample-1-2.json"), "{\"name\": \"1-2\"}".getBytes());
+        Files.write(testPack2Path.resolve("sample-2-1.json"), "{\"name\": \"2-1\"}".getBytes());
+        Files.write(testPack2Path.resolve("sample-2-2.json"), "{\"name\": \"2-2\"}".getBytes());
+
+        PipelineTreeConfig chain = helper.createNestedTreeConfigMultipleStartingNodes().strictUniqueIds().withWritePath(tempDir);
+        pipelineTestPackWriter.writeTestPacks(chain);
+
+        assertFileExists(tempDir, "regulatory-reporting/config/test-pack-report-middle-a-test-pack-1.json");
+        assertFileExists(tempDir, "regulatory-reporting/config/test-pack-report-middle-a-test-pack-2.json");
+        assertFileExists(tempDir, "regulatory-reporting/config/test-pack-report-middle-b-test-pack-1.json");
+        assertFileExists(tempDir, "regulatory-reporting/config/test-pack-report-middle-b-test-pack-2.json");
+
+        assertFileExists(tempDir, "projection/config/test-pack-projection-middle-a-end-a-test-pack-1.json");
+        assertFileExists(tempDir, "projection/config/test-pack-projection-middle-b-end-b-test-pack-2.json");
+        assertFileExists(tempDir, "projection/config/test-pack-projection-middle-a-end-b-test-pack-2.json");
+        assertFileExists(tempDir, "projection/config/test-pack-projection-middle-b-end-a-test-pack-1.json");
+        assertFileExists(tempDir, "projection/config/test-pack-projection-middle-b-end-a-test-pack-2.json");
+        assertFileExists(tempDir, "projection/config/test-pack-projection-middle-a-end-b-test-pack-1.json");
+        assertFileExists(tempDir, "projection/config/test-pack-projection-middle-b-end-b-test-pack-1.json");
+        assertFileExists(tempDir, "projection/config/test-pack-projection-middle-a-end-a-test-pack-2.json");
+
+        assertFileExists(tempDir, "regulatory-reporting/output/middle-a/test-pack-2/sample-2-2.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/middle-a/test-pack-2/sample-2-1.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/middle-a/test-pack-1/sample-1-1.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/middle-a/test-pack-1/sample-1-2.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/middle-a/test-pack-2/sample-2-2.json");
+
+        assertFileExists(tempDir, "regulatory-reporting/output/middle-b/test-pack-2/sample-2-2.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/middle-b/test-pack-2/sample-2-1.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/middle-b/test-pack-1/sample-1-1.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/middle-b/test-pack-1/sample-1-2.json");
+        assertFileExists(tempDir, "regulatory-reporting/output/middle-b/test-pack-2/sample-2-2.json");
+
+
+        assertFileExists(tempDir, "projection/output/middle-a/end-a/test-pack-2/sample-2-2.json");
+        assertFileExists(tempDir, "projection/output/middle-a/end-a/test-pack-2/sample-2-1.json");
+        assertFileExists(tempDir, "projection/output/middle-a/end-a/test-pack-1/sample-1-1.json");
+        assertFileExists(tempDir, "projection/output/middle-a/end-a/test-pack-1/sample-1-2.json");
+
+        assertFileExists(tempDir, "projection/output/middle-a/end-b/test-pack-2/sample-2-2.json");
+        assertFileExists(tempDir, "projection/output/middle-a/end-b/test-pack-2/sample-2-1.json");
+        assertFileExists(tempDir, "projection/output/middle-a/end-b/test-pack-1/sample-1-1.json");
+        assertFileExists(tempDir, "projection/output/middle-a/end-b/test-pack-1/sample-1-2.json");
+
+        assertFileExists(tempDir, "projection/output/middle-b/end-a/test-pack-2/sample-2-2.json");
+        assertFileExists(tempDir, "projection/output/middle-b/end-a/test-pack-2/sample-2-1.json");
+        assertFileExists(tempDir, "projection/output/middle-b/end-a/test-pack-1/sample-1-1.json");
+        assertFileExists(tempDir, "projection/output/middle-b/end-a/test-pack-1/sample-1-2.json");
+
+        assertFileExists(tempDir, "projection/output/middle-b/end-b/test-pack-2/sample-2-2.json");
+        assertFileExists(tempDir, "projection/output/middle-b/end-b/test-pack-2/sample-2-1.json");
+        assertFileExists(tempDir, "projection/output/middle-b/end-b/test-pack-1/sample-1-1.json");
+        assertFileExists(tempDir, "projection/output/middle-b/end-b/test-pack-1/sample-1-2.json");
+
     }
 
     private static void assertFileExists(Path tempDir, String fileName) {

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineTestUtils.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineTestUtils.java
@@ -1,0 +1,18 @@
+package com.regnosys.testing.pipeline;
+
+import com.rosetta.model.lib.RosettaModelObject;
+import com.rosetta.model.lib.functions.RosettaFunction;
+
+public class PipelineTestUtils {
+    static class Enrich_Type_1ToType_2 implements RosettaFunction {
+        public String evaluate(RosettaModelObject input) {
+            return "Enriched" + input;
+        }
+    }
+
+    static class Report_Type_2ToType_3 implements RosettaFunction {
+    }
+
+    static class Projection_Type_3ToType_4 implements RosettaFunction {
+    }
+}

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineTestUtils.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineTestUtils.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.rosetta.model.lib.RosettaModelObject;
 import com.rosetta.model.lib.functions.RosettaFunction;
 

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineTestUtils.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineTestUtils.java
@@ -13,6 +13,12 @@ public class PipelineTestUtils {
     static class Report_Type_2ToType_3 implements RosettaFunction {
     }
 
-    static class Projection_Type_3ToType_4 implements RosettaFunction {
+    static class Project_Type_3ToType_4 implements RosettaFunction {
+    }
+
+    static class Report_TYPE_2_TO_TYPE_3 implements RosettaFunction {
+        public String evaluate(RosettaModelObject input) {
+            return "Enriched" + input;
+        }
     }
 }

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineTreeBuilderTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineTreeBuilderTest.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineTreeBuilderTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineTreeBuilderTest.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.pipeline;
 
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.regnosys.rosetta.common.transform.PipelineModel;
 import com.regnosys.rosetta.common.transform.TransformType;
 import com.rosetta.model.lib.functions.RosettaFunction;


### PR DESCRIPTION
Model Maintainer can have unit tests for enrich based on transform pipelines so that enrichments can be regression tested and made available in Rosetta