### PR TITLE
task-5858: added annotation tag and comment

### DIFF
--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTreeConfig.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTreeConfig.java
@@ -47,6 +47,12 @@ public class PipelineTreeConfig {
     private Predicate<String> testPackIdFilter = testPackId -> true;
     private String modelId;
 
+
+/**
+ * @deprecated This constructor is here to prevent existing model extensions from breaking. It will be removed in the future
+ * as part of wider work. on the PipelineTreeConfig class.
+ */
+    @Deprecated
     public PipelineTreeConfig() {
         this(null);
     }


### PR DESCRIPTION
This adds a deprecated annotation to the PipelineTreeConfig zero arg constructor that will be removed in the future

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
