### PR TITLE
task-5939: fix null value in pipeline id

### DIFF
--- a/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
@@ -24,6 +24,7 @@ import com.regnosys.rosetta.common.transform.PipelineModel;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.regnosys.rosetta.common.transform.FunctionNameHelper;
@@ -58,7 +59,7 @@ public class PipelineModelBuilder {
         String pipelineId = modelBuilder.id(config.isStrictUniqueIds());
         String upstreamPipelineId = modelBuilder.upstreamId(config.isStrictUniqueIds());
 
-        String prefixedPipelineName = String.format("%s %s", config.getModelId(), name);
+        String prefixedPipelineName = Optional.ofNullable(config.getModelId()).map(mId -> String.format("%s %s", mId, name)).orElse(name);
         return new PipelineModel(pipelineId,
                 prefixedPipelineName,
                 new PipelineModel.Transform(modelBuilder.getTransformType(), modelBuilder.getFunction().getName(), inputType, outputType),

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
@@ -20,14 +20,13 @@ package com.regnosys.testing.pipeline;
  * ===============
  */
 
+import com.regnosys.rosetta.common.transform.FunctionNameHelper;
 import com.regnosys.rosetta.common.transform.PipelineModel;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
-
-import com.regnosys.rosetta.common.transform.FunctionNameHelper;
 
 
 public class PipelineModelBuilder {
@@ -59,7 +58,9 @@ public class PipelineModelBuilder {
         String pipelineId = modelBuilder.id(config.isStrictUniqueIds());
         String upstreamPipelineId = modelBuilder.upstreamId(config.isStrictUniqueIds());
 
-        String prefixedPipelineName = Optional.ofNullable(config.getModelId()).map(mId -> String.format("%s %s", mId, name)).orElse(name);
+        String modelId = config.getModelId();
+        String prefixedPipelineName = StringUtils.isEmpty(modelId) ? name : String.format("%s %s", modelId, name);
+        
         return new PipelineModel(pipelineId,
                 prefixedPipelineName,
                 new PipelineModel.Transform(modelBuilder.getTransformType(), modelBuilder.getFunction().getName(), inputType, outputType),

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineNode.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineNode.java
@@ -85,16 +85,19 @@ public class PipelineNode {
     }
 
     public String id(boolean strictUniqueIds) {
-        return String.format("pipeline-%s-%s-%s", getTransformType().name().toLowerCase(), modelId, idSuffix(strictUniqueIds, "-"));
+        String suffix = idSuffix(strictUniqueIds, "-");
+        return modelId.isEmpty()
+                ? String.format("pipeline-%s-%s", getTransformType().name().toLowerCase(), suffix)
+                : String.format("pipeline-%s-%s-%s", getTransformType().name().toLowerCase(), modelId, suffix);
     }
 
     public String upstreamId(boolean strictUniqueIds) {
-        if (strictUniqueIds) {
-            return (upstream == null) ? null :
-                    String.format("pipeline-%s-%s-%s", upstream.getTransformType().name().toLowerCase(), modelId, upstream.upstreamIdSuffix(strictUniqueIds, "-"));
+        if (upstream == null) {
+            return null;
         }
-        return (upstream == null) ? null :
-                String.format("pipeline-%s-%s-%s", upstream.getTransformType().name().toLowerCase(), modelId, upstream.idSuffix(strictUniqueIds, "-"));
+        String format = modelId.isEmpty() ? "pipeline-%s-%s" : "pipeline-%s-%s-%s";
+        String suffix = strictUniqueIds ? upstream.upstreamIdSuffix(strictUniqueIds, "-") : upstream.idSuffix(strictUniqueIds, "-");
+        return String.format(format, upstream.getTransformType().name().toLowerCase(), modelId, suffix).replaceAll("-$", "");
     }
 
     private String upstreamIdSuffix(boolean strictUniqueIds, String separator) {

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTreeConfig.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTreeConfig.java
@@ -54,7 +54,7 @@ public class PipelineTreeConfig {
  */
     @Deprecated
     public PipelineTreeConfig() {
-        this("");
+        this(null);
     }
 
     public PipelineTreeConfig(String modelId) {

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTreeConfig.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTreeConfig.java
@@ -54,7 +54,7 @@ public class PipelineTreeConfig {
  */
     @Deprecated
     public PipelineTreeConfig() {
-        this(null);
+        this("");
     }
 
     public PipelineTreeConfig(String modelId) {

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineNodeTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineNodeTest.java
@@ -44,12 +44,15 @@ class PipelineNodeTest {
 
     private static final boolean NO_STRICT_IDs = false;
 
+    private static PipelineNode EMPTY_MODEL_ID_NODE;
+
     @BeforeEach
     void setUp() {
         PipelineTestHelper.setupInjector(this);
         ENRICH_NODE = new PipelineNode("prefix", functionNameHelper, TransformType.ENRICH, PipelineTestUtils.Enrich_Type_1ToType_2.class, null);
         REPORT_NODE = new PipelineNode("prefix", functionNameHelper, TransformType.REPORT, PipelineTestUtils.Report_Type_2ToType_3.class, ENRICH_NODE);
         PROJECTION_NODE = new PipelineNode("prefix", functionNameHelper, TransformType.PROJECTION, PipelineTestUtils.Project_Type_3ToType_4.class, REPORT_NODE);
+        EMPTY_MODEL_ID_NODE = new PipelineNode("", functionNameHelper, TransformType.ENRICH, PipelineTestUtils.Enrich_Type_1ToType_2.class, null);
     }
 
     @Test
@@ -96,4 +99,30 @@ class PipelineNodeTest {
     void idSuffixWithoutStrictIdsChildNode() {
         assertEquals("type3-to-type4", PROJECTION_NODE.idSuffix(NO_STRICT_IDs, "-"));
     }
+
+    @Test
+    void idWithEmptyModelId() {
+        assertEquals("pipeline-enrich-type1-to-type2", EMPTY_MODEL_ID_NODE.id(STRICT_IDS));
+    }
+
+    @Test
+    void idWithoutStrictIdsWithEmptyModelId() {
+        assertEquals("pipeline-enrich-type1-to-type2", EMPTY_MODEL_ID_NODE.id(NO_STRICT_IDs));
+    }
+
+    @Test
+    void nullUpstreamWithEmptyModelId() {
+        assertNull(EMPTY_MODEL_ID_NODE.upstreamId(STRICT_IDS));
+    }
+
+    @Test
+    void idSuffixWithEmptyModelId() {
+        assertEquals("type1-to-type2", EMPTY_MODEL_ID_NODE.idSuffix(STRICT_IDS, "-"));
+    }
+
+    @Test
+    void idSuffixWithoutStrictIdsWithEmptyModelId() {
+        assertEquals("type1-to-type2", EMPTY_MODEL_ID_NODE.idSuffix(NO_STRICT_IDs, "-"));
+    }
+
 }

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineTestPackWriterTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineTestPackWriterTest.java
@@ -230,7 +230,7 @@ public class PipelineTestPackWriterTest {
         Files.write(testPackBPath.resolve("sample-1-1.json"), "{\"name\": \"1-1\"}".getBytes());
         Files.write(testPackCPath.resolve("sample-1-1.json"), "{\"name\": \"1-1\"}".getBytes());
 
-        PipelineTreeConfig chain = new PipelineTreeConfig(null)
+        PipelineTreeConfig chain = new PipelineTreeConfig()
                 .withTestPackIdFilter(startsWith("test-pack-a", "test-pack-1", "test-pack-2").
                         and(Predicate.not(startsWith("test-pack-b", "test-pack-only-c"))))
                 .starting(TransformType.REPORT, helper.middleAClass())
@@ -251,7 +251,7 @@ public class PipelineTestPackWriterTest {
     @Test
     void writeSegregatedTestPacksWithFilter(@TempDir Path tempDir) throws Exception {
         // Trade Report Pipeline, startClass == TradeInstruction, middleClass == TradeReport, endClass == TradeProject
-        PipelineTreeConfig tradeReportConf = new PipelineTreeConfig(null)
+        PipelineTreeConfig tradeReportConf = new PipelineTreeConfig()
                 .withTestPackIdFilter(startsWith("trade"))
                 .starting(TransformType.ENRICH, helper.startClass())
                 .add(helper.startClass(), TransformType.REPORT, helper.middleClass())
@@ -265,7 +265,7 @@ public class PipelineTestPackWriterTest {
         Files.write(tradeTestPack1Path.resolve("t-1-2.json"), "{\"name\": \"1-2t\"}".getBytes());
         
         // Valuation Report Pipeline, middleBClass == ValuationReport. endBClass == ValuationProject
-        PipelineTreeConfig valuationReportConf = new PipelineTreeConfig(null)
+        PipelineTreeConfig valuationReportConf = new PipelineTreeConfig()
                 .withTestPackIdFilter(startsWith("valuation"))
                 .starting(TransformType.REPORT, helper.middleBClass())
                 .add(helper.middleBClass(), TransformType.PROJECTION, helper.endBClass())


### PR DESCRIPTION
Please include a summary of the change and the issue/story number.

Currently, we are passing null in our zero arg constructor. This results in null being parsed as a value during pipelineID generation. When a modelID/prefix is not available, we should not add anything to the pipelineID. 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

