### PR TITLE
Update Maven coordinates and remove references to rosetta-backport

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -81,7 +81,8 @@ steps:
       - bash -c "${{GPG_IMPORT_COMMAND}}"
       - mvn ${{MVN_CLI_OPT}} versions:set -DnewVersion=${{RELEASE_NAME}}
       - mvn ${{MVN_SET_VERSION}} -Dproperty=rune.common.version
-      - if [ "${{CF_PULL_REQUEST_TARGET}}" = "main" ] || [ "${{CF_BRANCH}}" = "main" ]; then echo "Using FINOS credentials"; export CI_DEPLOY_USERNAME="${CI_DEPLOY_USERNAME_FINOS}"; export CI_DEPLOY_PASSWORD="${CI_DEPLOY_PASSWORD_FINOS}"; else echo "Using default REGnosys credentials"; export CI_DEPLOY_USERNAME="${CI_DEPLOY_USERNAME}"; export CI_DEPLOY_PASSWORD="${CI_DEPLOY_PASSWORD}"; fi
+      - export CI_DEPLOY_USERNAME="${{CI_DEPLOY_USERNAME_FINOS}}"
+      - export CI_DEPLOY_PASSWORD="${{CI_DEPLOY_PASSWORD_FINOS}}"
       - export GPG_KEYNAME="${{GPG_KEYNAME}}"
       - export GPG_PASSPHRASE="${{GPG_PASSPHRASE}}"
       - mvn -U -B ${{MVN_CLI_OPT}} clean install org.sonatype.central:central-publishing-maven-plugin:0.7.0:publish -P release

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -81,8 +81,7 @@ steps:
       - bash -c "${{GPG_IMPORT_COMMAND}}"
       - mvn ${{MVN_CLI_OPT}} versions:set -DnewVersion=${{RELEASE_NAME}}
       - mvn ${{MVN_SET_VERSION}} -Dproperty=rune.common.version
-      - export CI_DEPLOY_USERNAME="${{CI_DEPLOY_USERNAME}}"
-      - export CI_DEPLOY_PASSWORD="${{CI_DEPLOY_PASSWORD}}"
+      - if [ "${{CF_PULL_REQUEST_TARGET}}" = "main" ] || [ "${{CF_BRANCH}}" = "main" ]; then echo "Using FINOS credentials"; export CI_DEPLOY_USERNAME="${CI_DEPLOY_USERNAME_FINOS}"; export CI_DEPLOY_PASSWORD="${CI_DEPLOY_PASSWORD_FINOS}"; else echo "Using default REGnosys credentials"; export CI_DEPLOY_USERNAME="${CI_DEPLOY_USERNAME}"; export CI_DEPLOY_PASSWORD="${CI_DEPLOY_PASSWORD}"; fi
       - export GPG_KEYNAME="${{GPG_KEYNAME}}"
       - export GPG_PASSPHRASE="${{GPG_PASSPHRASE}}"
       - mvn -U -B ${{MVN_CLI_OPT}} clean install org.sonatype.central:central-publishing-maven-plugin:0.7.0:publish -P release

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     </parent>
 
     <name>Rune Testing</name>
+    <groupId>org.finos.rune-testing</groupId>
     <artifactId>rune-testing</artifactId>
     <packaging>jar</packaging>
     <version>0.0.0.main-SNAPSHOT</version>
@@ -164,8 +165,8 @@
                 <version>${rune.dsl.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.regnosys</groupId>
-                <artifactId>rosetta-common</artifactId>
+                <groupId>org.finos.rune-common</groupId>
+                <artifactId>rune-common</artifactId>
                 <version>${rune.common.version}</version>
             </dependency>
             <dependency>
@@ -262,8 +263,8 @@
             <artifactId>rune-testing</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.regnosys</groupId>
-            <artifactId>rosetta-common</artifactId>
+            <groupId>org.finos.rune-common</groupId>
+            <artifactId>rune-common</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,19 +31,17 @@
     </parent>
 
     <name>Rune Testing</name>
-    <groupId>com.regnosys</groupId>
-    <artifactId>rosetta-testing</artifactId>
+    <artifactId>rune-testing</artifactId>
     <packaging>jar</packaging>
     <version>0.0.0.main-SNAPSHOT</version>
     <url>https://github.com/REGnosys/rosetta-testing</url>
 
     <scm>
-        <developerConnection>scm:git:https://github.com/REGnosys/rosetta-testing</developerConnection>
-        <connection>scm:git:git://github.com/REGnosys/rosetta-testing.git</connection>
+        <developerConnection>scm:git:https://github.com/finos/rune-testing</developerConnection>
+        <connection>scm:git:git://github.com/finos/rune-testing.git</connection>
         <tag>HEAD</tag>
-        <url>https://github.com/REGnosys/rosetta-testing</url>
+        <url>https://github.com/finos/rune-testing</url>
     </scm>
-
     <description>Rune Testing is a java library that is utilised by Rosetta Code Generators and models expressed in the Rosetta DSL.</description>
 
     <organization>
@@ -61,10 +59,10 @@
 
     <developers>
         <developer>
-            <id>minesh-s-patel</id>
-            <name>Minesh Patel</name>
+            <id>hugohills-regnosys</id>
+            <name>Hugo Hills</name>
             <email>infra@regnosys.com</email>
-            <url>http://github.com/minesh-s-patel</url>
+            <url>http://github.com/hugohills-regnosys</url>
             <organization>REGnosys</organization>
             <organizationUrl>https://regnosys.com</organizationUrl>
             <timezone>+1</timezone>
@@ -74,10 +72,10 @@
             </roles>
         </developer>
         <developer>
-            <id>hugohills-regnosys</id>
-            <name>Hugo Hills</name>
+            <id>JayasriR</id>
+            <name>Jayasri Radhakrishnan</name>
             <email>infra@regnosys.com</email>
-            <url>http://github.com/hugohills-regnosys</url>
+            <url>http://github.com/JayasriR</url>
             <organization>REGnosys</organization>
             <organizationUrl>https://regnosys.com</organizationUrl>
             <timezone>+1</timezone>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
             <artifactId>rune-testing</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.finos.rune-common</groupId>
+            <groupId>org.finos</groupId>
             <artifactId>rune-common</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
             <artifactId>rune-testing</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.finos</groupId>
+            <groupId>org.finos.rune-common</groupId>
             <artifactId>rune-common</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Removed backport of old Maven GAV coordinates `com.regnosys.rosetta`
- Rename bundle Maven GAV coordinates com.regnosys:rosetta-testing to org.finos.rune-testing

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
