### PR TITLE
[11.x.x] - Migrate DSL to finos 9.85.0 and backport pipeline serialisation (blocked on rune-common#668)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <rosetta.dsl.version>9.84.0</rosetta.dsl.version>
+        <rune.dsl.version>9.85.0</rune.dsl.version>
         <rosetta.common.version>0.0.0.11.x.x-SNAPSHOT</rosetta.common.version>
 
         <xtext.version>2.38.0</xtext.version>
@@ -156,14 +156,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>com.regnosys.rosetta</artifactId>
-                <version>${rosetta.dsl.version}</version>
+                <groupId>org.finos.rune</groupId>
+                <artifactId>rune-lang</artifactId>
+                <version>${rune.dsl.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>com.regnosys.rosetta.tests</artifactId>
-                <version>${rosetta.dsl.version}</version>
+                <groupId>org.finos.rune</groupId>
+                <artifactId>rune-testing</artifactId>
+                <version>${rune.dsl.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.regnosys</groupId>
@@ -256,12 +256,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-lang</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta.tests</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-testing</artifactId>
         </dependency>
         <dependency>
             <groupId>com.regnosys</groupId>

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineFunctionRunnerProviderImpl.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineFunctionRunnerProviderImpl.java
@@ -40,7 +40,6 @@ import jakarta.inject.Inject;
 import javax.xml.validation.Validator;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Optional;
 import java.util.function.Function;
 
 public class PipelineFunctionRunnerProviderImpl implements PipelineFunctionRunnerProvider {
@@ -65,18 +64,16 @@ public class PipelineFunctionRunnerProviderImpl implements PipelineFunctionRunne
                                          ObjectMapper defaultJsonObjectMapper,
                                          ObjectWriter defaultJsonObjectWriter,
                                          Validator outputXsdValidator) {
-        // Input de-serialisation
-        ObjectMapper inputObjectMapper = Optional.ofNullable(inputSerialisation)
-                .flatMap(TestPackUtils::getObjectMapper)
-                .orElse(defaultJsonObjectMapper);
-        // Output serialisation. The CSV_LABELLED format needs a LabelProvider, which the Rune DSL
-        // generates onto the transform function class (@RuneLabelProvider). The function class is
-        // already loaded and in hand here, so resolve the provider from it directly rather than
-        // threading a ClassLoader across the API. The provider is only resolved for CSV_LABELLED.
+        // Input/output (de)serialisation is resolved by TestPackUtils: the pipeline's serialisation when
+        // present, otherwise the function's @Ingest/@Projection annotation (which a serialisation-agnostic
+        // pipeline omits), otherwise the default JSON mapper/writer. The CSV_LABELLED format of a pipeline
+        // outputSerialisation needs a LabelProvider resolved from the function class (@RuneLabelProvider);
+        // the annotation path resolves its own inside TransformObjectMapperFactory.
+        ObjectMapper inputObjectMapper =
+                TestPackUtils.getInputObjectMapper(inputSerialisation, functionType, defaultJsonObjectMapper);
         LabelProvider labelProvider = resolveLabelProvider(outputSerialisation, functionType);
-        ObjectWriter outputObjectWriter = Optional.ofNullable(outputSerialisation)
-                .flatMap(serialisation -> TestPackUtils.getObjectWriter(serialisation, labelProvider))
-                .orElse(defaultJsonObjectWriter);
+        ObjectWriter outputObjectWriter =
+                TestPackUtils.getOutputObjectWriter(outputSerialisation, functionType, labelProvider, defaultJsonObjectWriter);
 
         return createTestPackFunctionRunner(transformType,
                 functionType,

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
@@ -63,10 +63,11 @@ public class PipelineModelBuilder {
         // serialised to compare against expectations; an @Projection function's input is deserialised),
         // so it keeps coming from the deprecated config maps on PipelineTreeConfig
         // (withXmlConfigMap/withInputSerialisationFormatMap/...).
-        PipelineModel.Serialisation inputSerialisation =
-                inputSerialisationFromAnnotation(function).isPresent() ? null : mapBasedInputSerialisation(function, config);
-        PipelineModel.Serialisation outputSerialisation =
-                outputSerialisationFromAnnotation(function).isPresent() ? null : mapBasedOutputSerialisation(function, config);
+
+        //Replace this with inputSerialisationFromAnnotation(function).isPresent() ? null : mapBasedInputSerialisation(function, config); once we have models with annotations rolled out.
+        PipelineModel.Serialisation inputSerialisation = mapBasedInputSerialisation(function, config);
+        //Replace this with outputSerialisationFromAnnotation(function).isPresent() ? null : mapBasedOutputSerialisation(function, config);once we have models with annotations rolled out.
+        PipelineModel.Serialisation outputSerialisation = mapBasedOutputSerialisation(function, config);
 
         String pipelineId = modelBuilder.id(config.isStrictUniqueIds());
         String upstreamPipelineId = modelBuilder.upstreamId(config.isStrictUniqueIds());

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineModelBuilder.java
@@ -22,14 +22,16 @@ package com.regnosys.testing.pipeline;
 
 import com.regnosys.rosetta.common.transform.FunctionNameHelper;
 import com.regnosys.rosetta.common.transform.PipelineModel;
+import com.rosetta.model.lib.functions.RosettaFunction;
+import com.rosetta.model.lib.transform.Ingest;
+import com.rosetta.model.lib.transform.Projection;
+import com.rosetta.model.lib.transform.SerializationFormat;
 import org.apache.commons.lang3.StringUtils;
 
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static com.regnosys.rosetta.common.transform.TestPackUtils.getSerialisation;
 
 
 public class PipelineModelBuilder {
@@ -48,21 +50,23 @@ public class PipelineModelBuilder {
     }
 
     protected PipelineModel build(PipelineNode modelBuilder, PipelineTreeConfig config) {
-        String inputType = helper.getInputType(modelBuilder.getFunction());
-        String outputType = helper.getOutputType(modelBuilder.getFunction());
-        String inputSerialisationConfigPath = config.getXmlConfigMap().get(helper.getInputClass(modelBuilder.getFunction()));
-        String outputSerialisationConfigPath = config.getXmlConfigMap().get(helper.getFuncMethod(modelBuilder.getFunction()).getReturnType());
-        PipelineModel.Serialisation.Format inputSerialisationFormat = Optional.ofNullable(config.getInputSerialisationFormatMap())
-                .map(formatMap -> formatMap.get(helper.getInputClass(modelBuilder.getFunction())))
-                .orElse(null);
-        PipelineModel.Serialisation.Format outputSerialisationFormat = Optional.ofNullable(config.getOutputSerialisationFormatMap())
-                .map(formatMap ->  formatMap.get(helper.getFuncMethod(modelBuilder.getFunction()).getReturnType()))
-                .orElse(null);
-        String name = helper.getName(modelBuilder.getFunction());
+        Class<? extends RosettaFunction> function = modelBuilder.getFunction();
+        String inputType = helper.getInputType(function);
+        String outputType = helper.getOutputType(function);
+        String name = helper.getName(function);
 
-        // assume XML when serialisation format is null and config is populated
-        PipelineModel.Serialisation inputSerialisation = getSerialisation(inputSerialisationFormat, inputSerialisationConfigPath);
-        PipelineModel.Serialisation outputSerialisation = getSerialisation(outputSerialisationFormat, outputSerialisationConfigPath);
+        // A serialisation-agnostic pipeline does not record the serialisation that the function's
+        // @Ingest/@Projection annotation already expresses: @Ingest covers the input, @Projection the
+        // output, and the object mapper for that direction is built from the annotation directly (as in
+        // rosetta-products). So we deliberately omit that direction here. The opposite direction is not
+        // expressed by the annotation but is still needed for testing (an @Ingest function's output is
+        // serialised to compare against expectations; an @Projection function's input is deserialised),
+        // so it keeps coming from the deprecated config maps on PipelineTreeConfig
+        // (withXmlConfigMap/withInputSerialisationFormatMap/...).
+        PipelineModel.Serialisation inputSerialisation =
+                inputSerialisationFromAnnotation(function).isPresent() ? null : mapBasedInputSerialisation(function, config);
+        PipelineModel.Serialisation outputSerialisation =
+                outputSerialisationFromAnnotation(function).isPresent() ? null : mapBasedOutputSerialisation(function, config);
 
         String pipelineId = modelBuilder.id(config.isStrictUniqueIds());
         String upstreamPipelineId = modelBuilder.upstreamId(config.isStrictUniqueIds());
@@ -78,5 +82,79 @@ public class PipelineModelBuilder {
                 outputSerialisation,
                 modelId
         );
+    }
+
+    /**
+     * Whether the function carries an {@link Ingest} or {@link Projection} transform annotation. The
+     * annotation supplies the serialisation for the direction it governs (the input for {@code @Ingest},
+     * the output for {@code @Projection}); the opposite direction is not expressed by the annotation and
+     * still comes from the deprecated pipeline config maps.
+     */
+    static boolean hasTransformAnnotation(Class<? extends RosettaFunction> function) {
+        return function.isAnnotationPresent(Ingest.class) || function.isAnnotationPresent(Projection.class);
+    }
+
+    /**
+     * Derives the input serialisation from the function's {@link Ingest} annotation, if present.
+     */
+    static Optional<PipelineModel.Serialisation> inputSerialisationFromAnnotation(Class<? extends RosettaFunction> function) {
+        Ingest ingest = function.getAnnotation(Ingest.class);
+        return ingest == null ? Optional.empty() : Optional.of(toSerialisation(ingest.format(), ingest.configPath()));
+    }
+
+    /**
+     * Derives the output serialisation from the function's {@link Projection} annotation, if present.
+     */
+    static Optional<PipelineModel.Serialisation> outputSerialisationFromAnnotation(Class<? extends RosettaFunction> function) {
+        Projection projection = function.getAnnotation(Projection.class);
+        return projection == null ? Optional.empty() : Optional.of(toSerialisation(projection.format(), projection.configPath()));
+    }
+
+    static PipelineModel.Serialisation toSerialisation(SerializationFormat format, String configPath) {
+        return toSerialisation(PipelineModel.Serialisation.Format.valueOf(format.name()), configPath);
+    }
+
+    /**
+     * Builds a {@link PipelineModel.Serialisation} from a format and config path, treating every format
+     * uniformly: any format may carry a config path, and none is given special treatment.
+     */
+    static PipelineModel.Serialisation toSerialisation(PipelineModel.Serialisation.Format format, String configPath) {
+        if (format == null) {
+            return null;
+        }
+        String resolvedConfigPath = (configPath == null || configPath.isEmpty()) ? null : configPath;
+        return new PipelineModel.Serialisation(format, resolvedConfigPath);
+    }
+
+    /**
+     * @deprecated The serialisation format and config path are now derived from the function's
+     * {@link Ingest}/{@link Projection} annotation (see {@link #inputSerialisationFromAnnotation}).
+     * This map-based fallback only exists for models whose code generator does not yet emit those
+     * annotations and will be removed once they all do.
+     */
+    @Deprecated
+    private PipelineModel.Serialisation mapBasedInputSerialisation(Class<? extends RosettaFunction> function, PipelineTreeConfig config) {
+        Class<?> inputClass = helper.getInputClass(function);
+        String configPath = config.getXmlConfigMap().get(inputClass);
+        PipelineModel.Serialisation.Format format = Optional.ofNullable(config.getInputSerialisationFormatMap())
+                .map(formatMap -> formatMap.get(inputClass))
+                .orElse(null);
+        return toSerialisation(format, configPath);
+    }
+
+    /**
+     * @deprecated The serialisation format and config path are now derived from the function's
+     * {@link Ingest}/{@link Projection} annotation (see {@link #outputSerialisationFromAnnotation}).
+     * This map-based fallback only exists for models whose code generator does not yet emit those
+     * annotations and will be removed once they all do.
+     */
+    @Deprecated
+    private PipelineModel.Serialisation mapBasedOutputSerialisation(Class<? extends RosettaFunction> function, PipelineTreeConfig config) {
+        Class<?> returnType = helper.getFuncMethod(function).getReturnType();
+        String configPath = config.getXmlConfigMap().get(returnType);
+        PipelineModel.Serialisation.Format format = Optional.ofNullable(config.getOutputSerialisationFormatMap())
+                .map(formatMap -> formatMap.get(returnType))
+                .orElse(null);
+        return toSerialisation(format, configPath);
     }
 }

--- a/src/test/java/com/regnosys/testing/pipeline/PipelineModelBuilderAnnotationTest.java
+++ b/src/test/java/com/regnosys/testing/pipeline/PipelineModelBuilderAnnotationTest.java
@@ -1,0 +1,191 @@
+package com.regnosys.testing.pipeline;
+
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2025 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
+import com.google.common.collect.ImmutableMap;
+import com.regnosys.rosetta.common.transform.FunctionNameHelper;
+import com.regnosys.rosetta.common.transform.PipelineModel;
+import com.regnosys.rosetta.common.transform.TransformType;
+import com.rosetta.model.lib.functions.RosettaFunction;
+import com.rosetta.model.lib.transform.Enrich;
+import com.rosetta.model.lib.transform.Ingest;
+import com.rosetta.model.lib.transform.Projection;
+import com.rosetta.model.lib.transform.SerializationFormat;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies how pipeline serialisation relates to the {@code @Ingest}/{@code @Projection} annotation the
+ * code generator places on the function class.
+ * <p>
+ * The annotation supplies the serialisation only for the direction it governs ({@code @Ingest} the input,
+ * {@code @Projection} the output). The opposite direction is still needed for testing but is not expressed
+ * by the annotation, so the builder keeps deriving it from the deprecated config maps. These tests cover
+ * both the per-direction annotation helpers and the combined {@link PipelineModelBuilder#build} behaviour.
+ */
+class PipelineModelBuilderAnnotationTest {
+
+    @Ingest(id = "fixml", format = SerializationFormat.XML, configPath = "xml-config/fixml-xml-config.json")
+    private static class XmlSchemaIngestFunction implements RosettaFunction {
+    }
+
+    @Ingest(format = SerializationFormat.XML)
+    private static class BareXmlIngestFunction implements RosettaFunction {
+    }
+
+    @Projection(format = SerializationFormat.JSON)
+    private static class JsonProjectionFunction implements RosettaFunction {
+    }
+
+    @Enrich
+    private static class EnrichFunction implements RosettaFunction {
+    }
+
+    private static class UnannotatedFunction implements RosettaFunction {
+    }
+
+    private static class InputThing {
+    }
+
+    private static class OutputThing {
+    }
+
+    @Ingest(format = SerializationFormat.XML, configPath = "xml-config/in.json")
+    private static class IngestFunctionWithBody implements RosettaFunction {
+        public OutputThing evaluate(InputThing input) {
+            return null;
+        }
+    }
+
+    @Projection(format = SerializationFormat.JSON)
+    private static class ProjectionFunctionWithBody implements RosettaFunction {
+        public OutputThing evaluate(InputThing input) {
+            return null;
+        }
+    }
+
+    @Test
+    void annotatedFunctionsCarryTransformAnnotation() {
+        assertTrue(PipelineModelBuilder.hasTransformAnnotation(XmlSchemaIngestFunction.class));
+        assertTrue(PipelineModelBuilder.hasTransformAnnotation(BareXmlIngestFunction.class));
+        assertTrue(PipelineModelBuilder.hasTransformAnnotation(JsonProjectionFunction.class));
+    }
+
+    @Test
+    void ingestOmitsInputSerialisationButKeepsOutputFromPipelineMap() {
+        FunctionNameHelper helper = new FunctionNameHelper();
+        PipelineModelBuilder builder = new PipelineModelBuilder(helper);
+        // The pipeline still configures the output serialisation (the direction @Ingest does not cover).
+        PipelineTreeConfig config = new PipelineTreeConfig()
+                .withOutputSerialisationFormatMap(ImmutableMap.of(OutputThing.class, PipelineModel.Serialisation.Format.JSON));
+        PipelineNode node = new PipelineNode("test", helper, TransformType.TRANSLATE, IngestFunctionWithBody.class, null);
+
+        PipelineModel model = builder.build(node, config);
+
+        // input is omitted - the @Ingest annotation expresses it and the object mapper reads it directly
+        assertNull(model.getInputSerialisation());
+        // output still comes from the pipeline map
+        assertEquals(PipelineModel.Serialisation.Format.JSON, model.getOutputSerialisation().getFormat());
+    }
+
+    @Test
+    void projectionOmitsOutputSerialisationButKeepsInputFromPipelineMap() {
+        FunctionNameHelper helper = new FunctionNameHelper();
+        PipelineModelBuilder builder = new PipelineModelBuilder(helper);
+        // The pipeline still configures the input serialisation (the direction @Projection does not cover).
+        PipelineTreeConfig config = new PipelineTreeConfig()
+                .withInputSerialisationFormatMap(ImmutableMap.of(InputThing.class, PipelineModel.Serialisation.Format.XML))
+                .withXmlConfigMap(ImmutableMap.of(InputThing.class, "xml-config/proj-in.json"));
+        PipelineNode node = new PipelineNode("test", helper, TransformType.PROJECTION, ProjectionFunctionWithBody.class, null);
+
+        PipelineModel model = builder.build(node, config);
+
+        // output is omitted - the @Projection annotation expresses it and the object mapper reads it directly
+        assertNull(model.getOutputSerialisation());
+        // input still comes from the pipeline map
+        assertEquals(PipelineModel.Serialisation.Format.XML, model.getInputSerialisation().getFormat());
+        assertEquals("xml-config/proj-in.json", model.getInputSerialisation().getConfigPath());
+    }
+
+    @Test
+    void unannotatedFunctionsFallBackToTheLegacyMapPath() {
+        // @Enrich carries no serialisation annotation, and a plain function carries none at all; both
+        // directions then come entirely from the deprecated config-map path.
+        assertFalse(PipelineModelBuilder.hasTransformAnnotation(EnrichFunction.class));
+        assertFalse(PipelineModelBuilder.hasTransformAnnotation(UnannotatedFunction.class));
+    }
+
+    @Test
+    void ingestSchemaProducesInputSerialisationWithConfigPath() {
+        Optional<PipelineModel.Serialisation> input =
+                PipelineModelBuilder.inputSerialisationFromAnnotation(XmlSchemaIngestFunction.class);
+
+        assertTrue(input.isPresent());
+        assertEquals(PipelineModel.Serialisation.Format.XML, input.get().getFormat());
+        assertEquals("xml-config/fixml-xml-config.json", input.get().getConfigPath());
+
+        // An ingest carries no output serialisation.
+        assertFalse(PipelineModelBuilder.outputSerialisationFromAnnotation(XmlSchemaIngestFunction.class).isPresent());
+    }
+
+    @Test
+    void bareXmlIngestProducesXmlFormatWithoutConfigPath() {
+        Optional<PipelineModel.Serialisation> input =
+                PipelineModelBuilder.inputSerialisationFromAnnotation(BareXmlIngestFunction.class);
+
+        assertTrue(input.isPresent());
+        assertEquals(PipelineModel.Serialisation.Format.XML, input.get().getFormat());
+        assertNull(input.get().getConfigPath());
+    }
+
+    @Test
+    void projectionProducesOutputSerialisation() {
+        Optional<PipelineModel.Serialisation> output =
+                PipelineModelBuilder.outputSerialisationFromAnnotation(JsonProjectionFunction.class);
+
+        assertTrue(output.isPresent());
+        assertEquals(PipelineModel.Serialisation.Format.JSON, output.get().getFormat());
+        assertNull(output.get().getConfigPath());
+
+        // A projection carries no input serialisation.
+        assertFalse(PipelineModelBuilder.inputSerialisationFromAnnotation(JsonProjectionFunction.class).isPresent());
+    }
+
+    @Test
+    void enrichHasNoSerialisation() {
+        assertFalse(PipelineModelBuilder.inputSerialisationFromAnnotation(EnrichFunction.class).isPresent());
+        assertFalse(PipelineModelBuilder.outputSerialisationFromAnnotation(EnrichFunction.class).isPresent());
+    }
+
+    @Test
+    void allDslFormatsMapToPipelineFormats() {
+        for (SerializationFormat format : SerializationFormat.values()) {
+            PipelineModel.Serialisation serialisation = PipelineModelBuilder.toSerialisation(format, "");
+            assertEquals(format.name(), serialisation.getFormat().name());
+            assertNull(serialisation.getConfigPath());
+        }
+    }
+}

--- a/src/test/java/util/UnusedModelElementFinderTest.java
+++ b/src/test/java/util/UnusedModelElementFinderTest.java
@@ -52,7 +52,9 @@ public class UnusedModelElementFinderTest {
         UnusedModelElementFinder unusedModelElementFinder = new UnusedModelElementFinder(models);
 
         unusedModelElementFinder.run();
-        assertEquals(7, unusedModelElementFinder.getListOfTypes().size(), unusedModelElementFinder.getListOfTypes().toString());
+        // 8 includes the built-in com.rosetta.model.SerializationFormat enum (present on the 11.x.x DSL line as of rune-dsl 9.85.0),
+        // which is unused by this test model.
+        assertEquals(8, unusedModelElementFinder.getListOfTypes().size(), unusedModelElementFinder.getListOfTypes().toString());
 
         assertTrue(unusedModelElementFinder.getListOfTypes().contains("cdm.test.Test1"), "ListOfTypes should contain cdm.test.Test1");
         assertTrue(unusedModelElementFinder.getListOfTypes().contains("cdm.test.Test2"), "ListOfTypes should contain cdm.test.Test2");
@@ -70,7 +72,9 @@ public class UnusedModelElementFinderTest {
         assertTrue(unusedModelElementFinder.getListOfUsedTypes().contains("cdm.test.TestEnum3UsedInFuncOnly"), "ListOfUsedTypes should contain cdm.test.TestEnum3UsedInFuncOnly");
 
 
-        assertEquals(2, unusedModelElementFinder.getListOfOrphanedTypes().size(), unusedModelElementFinder.getListOfOrphanedTypes().toString());
+        // 3 includes the built-in com.rosetta.model.SerializationFormat enum (present on the 11.x.x DSL line as of rune-dsl 9.85.0).
+        assertEquals(3, unusedModelElementFinder.getListOfOrphanedTypes().size(), unusedModelElementFinder.getListOfOrphanedTypes().toString());
+        assertTrue(unusedModelElementFinder.getListOfOrphanedTypes().contains("com.rosetta.model.SerializationFormat"), "ListOfOrphanedTypes should contain com.rosetta.model.SerializationFormat");
         assertTrue(unusedModelElementFinder.getListOfOrphanedTypes().contains("cdm.test.TestEnum2Unused"), "ListOfOrphanedTypes should contain cdm.test.TestEnum2Unused");
         assertTrue(unusedModelElementFinder.getListOfOrphanedTypes().contains("cdm.test.Test4Unused"), "ListOfOrphanedTypes should contain cdm.test.Test4Unused");
 


### PR DESCRIPTION
> **Draft — blocked on finos/rune-common#668.** This backport depends on rune-common's transform-mapper pair (`TransformObjectMapperFactory`), which is in #668. CI here will stay red until #668 is merged and a `rosetta-common` 11.x.x with the transform pair is published. Verified locally against that SNAPSHOT: `mvn clean install` (Java 21) → 61 tests, 0 failures.

Backports the annotation-driven pipeline serialisation to `11.x.x`, and migrates the DSL dependency to the finos-published rune-dsl `9.85.0`.

## DSL dependency migration
`11.x.x` previously depended on the legacy `com.regnosys.rosetta:com.regnosys.rosetta` / `.tests` `9.84.0`, which lacks `com.rosetta.model.lib.transform`. This moves to **`org.finos.rune:rune-lang` / `rune-testing` `9.85.0`** (same DSL 9.x major, finos coordinates). The `rosetta-common` dependency is unchanged (rune-common's own 11.x.x coordinates stay `com.regnosys`).

## Backported changes
- #336 — Derive pipeline serialisation from the transform annotation
- #343 — Update pipeline serialization to use a map-based implementation

The built-in `com.rosetta.model.SerializationFormat` enum is present on the 11.x.x DSL line as of 9.85.0, so `UnusedModelElementFinderTest`'s type counts were resolved to include it (8 types / 3 orphaned).

## Excluded
DSL-10 version bumps, the finos rename of rune-testing's own coordinates, and #345 (requires rune-dsl 10.1.1) are out of scope — `11.x.x` stays on the DSL 9.x line.
