### PR TITLE
Update DSL to 10.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <rune.dsl.version>10.2.1</rune.dsl.version>
+        <rune.dsl.version>10.2.2</rune.dsl.version>
         <rune.common.version>0.0.0.main-SNAPSHOT</rune.common.version>
 
         <xtext.version>2.38.0</xtext.version>


### PR DESCRIPTION
Updates the Rune DSL dependency to 10.2.2.

This picks up the DSL 10.2.2 release (fix for NPE when reading an attribute overridden to zero cardinality, finos/rune-dsl#1322).