### PR TITLE
fix: Windows compatibility — portable test-pack paths, tolerant assertions

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,38 @@
+name: PR Checks
+
+on:
+  pull_request:
+
+# Cancel previous jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-on-ubuntu:
+    name: Maven Build on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: temurin
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B clean package
+
+  build-on-windows:
+    name: Maven Build on Windows
+    runs-on: windows-latest
+    steps:
+    - name: Enable git long paths
+      run: git config --system core.longpaths true
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: temurin
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B clean package

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <rune.dsl.version>10.2.1</rune.dsl.version>
+        <rune.dsl.version>10.2.3</rune.dsl.version>
         <rune.common.version>0.0.0.main-SNAPSHOT</rune.common.version>
 
         <xtext.version>2.38.0</xtext.version>

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTestPackWriter.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTestPackWriter.java
@@ -60,6 +60,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.regnosys.rosetta.common.util.UrlUtils.getBaseFileName;
+import static com.regnosys.rosetta.common.util.UrlUtils.toPortableString;
 
 public class PipelineTestPackWriter {
 
@@ -207,7 +208,9 @@ public class PipelineTestPackWriter {
             String baseFileName = getBaseFileName(inputSample.toUri().toURL());
             String displayName = baseFileName.replace("-", " ");
 
-            TestPackModel.SampleModel sampleModel = new TestPackModel.SampleModel(baseFileName.toLowerCase(), displayName, inputSample.toString(), outputPath.toString(), assertions);
+            // Sample paths are stored in the test-pack model and resolved as classpath
+            // resources, so they always use "/" regardless of the platform separator
+            TestPackModel.SampleModel sampleModel = new TestPackModel.SampleModel(baseFileName.toLowerCase(), displayName, toPortableString(inputSample), toPortableString(outputPath), assertions);
             sampleModels.add(sampleModel);
 
             Files.createDirectories(resourcesPath.resolve(outputPath).getParent());

--- a/src/main/java/com/regnosys/testing/transform/TransformTestExtension.java
+++ b/src/main/java/com/regnosys/testing/transform/TransformTestExtension.java
@@ -63,6 +63,7 @@ import java.util.stream.Stream;
 import static com.regnosys.rosetta.common.transform.TestPackUtils.*;
 import static com.regnosys.rosetta.common.transform.TestPackUtils.getPipelineModel;
 import static com.regnosys.testing.TestingExpectationUtil.readStringFromResources;
+import static com.regnosys.testing.TestingExpectationUtil.normaliseLineEndings;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -197,7 +198,7 @@ public class TransformTestExtension<T> implements BeforeAllCallback, AfterAllCal
         }
 
         String expectedOutput = readStringFromResources(Path.of(sampleModel.getOutputPath()));
-        assertEquals(expectedOutput, actualOutput);
+        assertEquals(normaliseLineEndings(expectedOutput), normaliseLineEndings(actualOutput));
 
         TestPackModel.SampleModel.Assertions expectedAssertions = sampleModel.getAssertions();
         assertEquals(expectedAssertions, actualAssertions);

--- a/src/test/java/com/regnosys/testing/schemeimport/LatestSchemesImportTest.java
+++ b/src/test/java/com/regnosys/testing/schemeimport/LatestSchemesImportTest.java
@@ -84,7 +84,8 @@ public class LatestSchemesImportTest {
 
                 boolean isDirectory = false;
                 //check for files or directory
-                if (zipEntry.getName().endsWith(File.separator)) {
+                // Zip entry names always use "/" regardless of the platform separator
+                if (zipEntry.getName().endsWith("/")) {
                     isDirectory = true;
                 }
 


### PR DESCRIPTION
## Summary

Part of a cross-repo Windows-compatibility effort (see REGnosys/rosetta-products#6854 and finos/rune-common#675). Depends on the rune-common LF pretty-printer pin (finos/rune-common#675) for fully platform-independent expectation writing; intended to release after it.

- **`PipelineTestPackWriter`**: store sample input/output paths in the test-pack model with `/` via the existing `UrlUtils.toPortableString`. `Path.toString()` wrote backslashes on Windows into `test-pack-*.json`, which is later resolved as classpath resources (requires `/`) and committed to model repos. (Same class of bug was fixed downstream in rosetta-products' `SamplePathProviderImpl`.)
- **`TransformTestExtension`**: normalise line endings before comparing the expected output file with freshly serialised output — extends the existing `assertJsonEquals`/`normaliseLineEndings` convention to the main transform assertion path, which was comparing raw.
- **`LatestSchemesImportTest`**: zip entry names always use `/` per the ZIP spec; don't test them against `File.separator`.
- **`.gitattributes` pinning LF** so expectation files survive `core.autocrlf` on Windows. All tracked files are already LF in the index — no churn.

Verified with a full local `mvn clean install` (61 tests) against the rune-common branch, and the downstream chain (rosetta-code-generators, rosetta-components) rebuilt green on top.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)