### PR TITLE
[11.x.x] Fall back to pipeline serialisation config when the transform annotation carries none

### DIFF
--- a/src/main/java/com/regnosys/testing/pipeline/PipelineFunctionRunnerProviderImpl.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineFunctionRunnerProviderImpl.java
@@ -25,14 +25,13 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.inject.Injector;
 import com.regnosys.rosetta.common.hashing.ReferenceConfig;
 import com.regnosys.rosetta.common.postprocess.WorkflowPostProcessor;
-import com.regnosys.rosetta.common.transform.LabelProviderResolver;
+import com.regnosys.rosetta.common.serialisation.ClasspathTransformMapperFactory;
+import com.regnosys.rosetta.common.serialisation.TransformMapperFactory;
+import com.regnosys.rosetta.common.serialisation.TransformSerializationResolver;
 import com.regnosys.rosetta.common.transform.PipelineModel;
-import com.regnosys.rosetta.common.transform.TestPackUtils;
 import com.regnosys.rosetta.common.transform.TransformType;
 import com.regnosys.rosetta.common.validation.RosettaTypeValidator;
 import com.rosetta.model.lib.RosettaModelObject;
-import com.rosetta.model.lib.functions.LabelProvider;
-import com.rosetta.model.lib.functions.RosettaFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +54,12 @@ public class PipelineFunctionRunnerProviderImpl implements PipelineFunctionRunne
     @Inject
     WorkflowPostProcessor postProcessor;
 
+    // Models on the test-pack runner live on the application classpath, so the classpath factory is the
+    // right construction seam here (a runtime with isolated model classloaders implements its own).
+    private final TransformMapperFactory mapperFactory = new ClasspathTransformMapperFactory();
+
     @Override
+    @SuppressWarnings("deprecation") // the pipeline serialisation is a deprecated fallback for pre-annotation models
     public PipelineFunctionRunner create(TransformType transformType,
                                          Class<? extends RosettaModelObject> inputType,
                                          Class<?> functionType,
@@ -64,16 +68,16 @@ public class PipelineFunctionRunnerProviderImpl implements PipelineFunctionRunne
                                          ObjectMapper defaultJsonObjectMapper,
                                          ObjectWriter defaultJsonObjectWriter,
                                          Validator outputXsdValidator) {
-        // Input/output (de)serialisation is resolved by TestPackUtils: the pipeline's serialisation when
-        // present, otherwise the function's @Ingest/@Projection annotation (which a serialisation-agnostic
-        // pipeline omits), otherwise the default JSON mapper/writer. The CSV_LABELLED format of a pipeline
-        // outputSerialisation needs a LabelProvider resolved from the function class (@RuneLabelProvider);
-        // the annotation path resolves its own inside TransformObjectMapperFactory.
-        ObjectMapper inputObjectMapper =
-                TestPackUtils.getInputObjectMapper(inputSerialisation, functionType, defaultJsonObjectMapper);
-        LabelProvider labelProvider = resolveLabelProvider(outputSerialisation, functionType);
-        ObjectWriter outputObjectWriter =
-                TestPackUtils.getOutputObjectWriter(outputSerialisation, functionType, labelProvider, defaultJsonObjectWriter);
+        // Each side resolves from the function's @Ingest/@Projection annotation (the model's source of
+        // truth), falling back to the deprecated pipeline serialisation for models generated before
+        // transform annotations existed, and finally to the default JSON mapper/writer. Construction —
+        // including the CSV_LABELLED @RuneLabelProvider resolution — happens in the mapper factory.
+        ObjectMapper inputObjectMapper = TransformSerializationResolver.input(functionType, inputSerialisation)
+                .map(serialization -> mapperFactory.create(serialization, functionType))
+                .orElse(defaultJsonObjectMapper);
+        ObjectWriter outputObjectWriter = TransformSerializationResolver.output(functionType, outputSerialisation)
+                .map(serialization -> mapperFactory.createWriter(serialization, functionType))
+                .orElse(defaultJsonObjectWriter);
 
         return createTestPackFunctionRunner(transformType,
                 functionType,
@@ -81,24 +85,6 @@ public class PipelineFunctionRunnerProviderImpl implements PipelineFunctionRunne
                 inputObjectMapper,
                 outputObjectWriter,
                 outputXsdValidator);
-    }
-
-    /**
-     * Resolves the {@link LabelProvider} for the {@code CSV_LABELLED} output format from the
-     * transform function class (which carries the generated {@code @RuneLabelProvider}). Returns
-     * {@code null} for every other format, so the provider is never resolved unnecessarily.
-     * When the format is {@code CSV_LABELLED} but no provider can be resolved (function class
-     * missing or not a {@link RosettaFunction}), {@code null} is returned and
-     * {@link TestPackUtils#getObjectWriter(PipelineModel.Serialisation, LabelProvider)} throws.
-     */
-    private static LabelProvider resolveLabelProvider(PipelineModel.Serialisation outputSerialisation, Class<?> functionType) {
-        if (outputSerialisation == null
-                || outputSerialisation.getFormat() != PipelineModel.Serialisation.Format.CSV_LABELLED
-                || functionType == null
-                || !RosettaFunction.class.isAssignableFrom(functionType)) {
-            return null;
-        }
-        return LabelProviderResolver.fromTransformFunction(functionType.asSubclass(RosettaFunction.class));
     }
 
     private <IN extends RosettaModelObject> PipelineFunctionRunner createTestPackFunctionRunner(TransformType transformType,


### PR DESCRIPTION
## Summary

Backports the transform-mapper fallback fix (finos/main, rune-testing #345 + rune-common #652) to the `11.x.x` line.

`PipelineFunctionRunnerProviderImpl` resolved the input mapper / output writer through the deprecated `TestPackUtils.getInputObjectMapper`/`getOutputObjectWriter` shims, which read the `@Ingest`/`@Projection` annotation **without** the legacy pipeline-serialisation fallback. A model generated before transform annotations carried a config path (e.g. CDM on DSL 9.85.0) declares `@Ingest(format = XML)` with **no** `configPath`, while the FpML XML config ships only in the pipeline's `inputSerialisation`. Annotation-first-without-fallback dropped that config, built a bare (empty) XML mapper and **silently produced empty outputs**.

This is the regression reported on the latest `11.124.0` bundle (works on `11.122.2`, and on the `12.x`/`main` line which already has the fix).

The fix routes each side through the fallback-aware `TransformSerializationResolver.input/output(functionType, serialisation)` overload and constructs via `ClasspathTransformMapperFactory`, mirroring `finos/main`. The resolver already merges the legacy config file when the annotation has the format but no config path (rune-common, backported here in #668); this change simply uses that overload instead of the bare shim. The mapper factory also resolves the `CSV_LABELLED` `@RuneLabelProvider` itself, so the local `resolveLabelProvider` duplicate is removed.

## Reproduction & verification

Against CDM `6.x.x` updated to DSL 9.85.0 / bundle 11.124.0 ([finos/common-domain-model#4944](https://github.com/finos/common-domain-model/pull/4944)), `IngestFpmlConfirmationToTradeStateTest`:

- **Before:** `Tests run: 721, Failures: 721` — each expected the mapped `TradeState`, but was `<>` (empty).
- **After** (this branch's `rosetta-testing` built locally and run against bundle 11.124.0): `Tests run: 721, Failures: 0` — BUILD SUCCESS.

At runtime the resolver now logs the expected once-per-function deprecation notice, confirming the legacy pipeline XML config is being merged in:

> The input config file of transform function `cdm.ingest.fpml.confirmation.message.functions.Ingest_FpmlConfirmationToTradeState` is driven by the deprecated pipeline serialisation config…

## Type of change

- Bug fix (non-breaking change which fixes an issue)
