### PR TITLE
[11.x.x] - fix: Windows compatibility — portable test-pack paths, tolerant assertions (#355)

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,38 @@
+name: PR Checks
+
+on:
+  pull_request:
+
+# Cancel previous jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-on-ubuntu:
+    name: Maven Build on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: temurin
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B clean package
+
+  build-on-windows:
+    name: Maven Build on Windows
+    runs-on: windows-latest
+    steps:
+    - name: Enable git long paths
+      run: git config --system core.longpaths true
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: temurin
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B clean package

--- a/src/main/java/com/regnosys/testing/pipeline/PipelineTestPackWriter.java
+++ b/src/main/java/com/regnosys/testing/pipeline/PipelineTestPackWriter.java
@@ -59,6 +59,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.regnosys.rosetta.common.util.UrlUtils.getBaseFileName;
+import static com.regnosys.rosetta.common.util.UrlUtils.toPortableString;
 
 public class PipelineTestPackWriter {
 
@@ -207,7 +208,9 @@ public class PipelineTestPackWriter {
             String baseFileName = getBaseFileName(inputSample.toUri().toURL());
             String displayName = baseFileName.replace("-", " ");
 
-            TestPackModel.SampleModel sampleModel = new TestPackModel.SampleModel(baseFileName.toLowerCase(), displayName, inputSample.toString(), outputPath.toString(), assertions);
+            // Sample paths are stored in the test-pack model and resolved as classpath
+            // resources, so they always use "/" regardless of the platform separator
+            TestPackModel.SampleModel sampleModel = new TestPackModel.SampleModel(baseFileName.toLowerCase(), displayName, toPortableString(inputSample), toPortableString(outputPath), assertions);
             sampleModels.add(sampleModel);
 
             Files.createDirectories(resourcesPath.resolve(outputPath).getParent());

--- a/src/main/java/com/regnosys/testing/transform/TransformTestExtension.java
+++ b/src/main/java/com/regnosys/testing/transform/TransformTestExtension.java
@@ -63,6 +63,7 @@ import java.util.stream.Stream;
 import static com.regnosys.rosetta.common.transform.TestPackUtils.*;
 import static com.regnosys.rosetta.common.transform.TestPackUtils.getPipelineModel;
 import static com.regnosys.testing.TestingExpectationUtil.readStringFromResources;
+import static com.regnosys.testing.TestingExpectationUtil.normaliseLineEndings;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -197,7 +198,7 @@ public class TransformTestExtension<T> implements BeforeAllCallback, AfterAllCal
         }
 
         String expectedOutput = readStringFromResources(Path.of(sampleModel.getOutputPath()));
-        assertEquals(expectedOutput, actualOutput);
+        assertEquals(normaliseLineEndings(expectedOutput), normaliseLineEndings(actualOutput));
 
         TestPackModel.SampleModel.Assertions expectedAssertions = sampleModel.getAssertions();
         assertEquals(expectedAssertions, actualAssertions);

--- a/src/test/java/com/regnosys/testing/schemeimport/LatestSchemesImportTest.java
+++ b/src/test/java/com/regnosys/testing/schemeimport/LatestSchemesImportTest.java
@@ -84,7 +84,8 @@ public class LatestSchemesImportTest {
 
                 boolean isDirectory = false;
                 //check for files or directory
-                if (zipEntry.getName().endsWith(File.separator)) {
+                // Zip entry names always use "/" regardless of the platform separator
+                if (zipEntry.getName().endsWith("/")) {
                     isDirectory = true;
                 }
 


### PR DESCRIPTION
Backport of #355 (`354e06e86` on `main`) to the `11.x.x` line.

## What it contains

- **`PipelineTestPackWriter`** — write sample input/output paths with `UrlUtils.toPortableString`. They are stored in the test-pack model and resolved as classpath resources, so they must always use `/` regardless of the platform separator.
- **`TransformTestExtension`** — normalise line endings on both sides before comparing expected and actual transform output.
- **`LatestSchemesImportTest`** — match zip entry directories on `"/"` rather than `File.separator`; zip entry names always use `/`.
- **`.github/workflows/check-pr.yml`** — PR checks on Ubuntu and Windows.

## Backport notes

Cherry-picked with `-x`. One conflict in `pom.xml`, resolved by **keeping the `11.x.x` values** of `rune.dsl.version` and `rosetta.common.version`.

Upstream, this commit also bumped `rune.dsl.version` to 10.2.3 to pick up the DSL-side Windows fixes (finos/rune-dsl#1324). The 9.x equivalent is not released yet — finos/rune-dsl#1338 is the corresponding DSL backport; the version bump should flow through the normal bundle DSL update, not this PR.

Both helpers used here already exist on `11.x.x`: `UrlUtils.toPortableString` (rune-common) and `TestingExpectationUtil.normaliseLineEndings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)