### PR TITLE
[11.x.x] - Disambiguate the model rune-config via a build-generated marker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,9 @@
         <jaxb.version>2.3.1</jaxb.version>
         <guava.version>33.3.1-jre</guava.version>
         <plexus-utils.version>3.6.1</plexus-utils.version>
+        <!-- Matches the version resolved transitively via
+             rune-common -> rune-maven-plugin -> maven-plugin-api -> maven-artifact -->
+        <maven-artifact.version>3.9.14</maven-artifact.version>
 
         <!-- Release -->
         <gpg.keyname>configured-by-release-profile</gpg.keyname>
@@ -259,6 +262,15 @@
                 <artifactId>logback-core</artifactId>
                 <version>${logback.version}</version>
             </dependency>
+            <dependency>
+                <!-- Declared directly because DefaultModelSerialisation uses ComparableVersion at compile
+                     time, rather than relying on the transitive path
+                     (rune-common -> rune-maven-plugin -> maven-plugin-api -> maven-artifact); version
+                     matches the current transitive resolution, so this changes nothing today. -->
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
+                <version>${maven-artifact.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -282,6 +294,10 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
         </dependency>
         <!-- add junit in non-test scope -->
         <dependency>

--- a/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
+++ b/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
@@ -65,12 +65,15 @@ import java.util.stream.Collectors;
  * default. Instead, {@code rune-maven-plugin} writes a per-model marker,
  * {@value #MODEL_PROPERTIES_PATH}, recording whether that model ships its own config
  * ({@value #RUNE_CONFIG_PRESENT_IN_MODEL_KEY}), the model's repo identity ({@value #MODEL_ID_KEY}) and
- * the closure of its ancestor models' identities ({@value #ANCESTOR_MODELS_KEY}). All markers on the
+ * its <em>direct</em> model parents' identities ({@value #PARENT_MODELS_KEY}). All markers on the
  * classpath are enumerated and the <em>leaf</em> is elected — the marker whose {@code modelId} no other
- * marker claims among its {@code ancestorModels} — so the winner is computed from the model graph
- * itself, independent of classpath order. If any marker predates the ancestry keys (no
- * {@code modelId}), election is skipped and the first marker in classpath order wins, keeping older
- * model builds working. The winning marker's answer is authoritative: if it says the config is absent,
+ * marker claims among its {@code parentModels} — so the winner is computed from the model graph
+ * itself, independent of classpath order. Direct parents suffice: each intermediate model's own marker
+ * contributes the edge that rules its parent out, because a model that declares a parent must be built
+ * with a DSL/plugin version in step with its consumers (only <em>root</em> models may drift behind on
+ * pre-marker plugin versions, and a markerless jar cannot win an election). If any marker predates the
+ * ancestry keys (no {@code modelId}), election is skipped and the first marker in classpath order
+ * wins, keeping older model builds working. The winning marker's answer is authoritative: if it says the config is absent,
  * no config is looked up at all, even if one happens to be reachable via a dependency; if present, the
  * config is resolved relative to the marker's own container (its own jar or exploded classes
  * directory), never via a second classpath-order lookup that could resolve to a different container.
@@ -85,7 +88,7 @@ public final class DefaultModelSerialisation {
     static final String RUNE_MAVEN_PLUGIN_VERSION_KEY = "runeMavenPluginVersion";
     static final String MODEL_SOURCE_GAV_KEY = "modelSourceGav";
     static final String MODEL_ID_KEY = "modelId";
-    static final String ANCESTOR_MODELS_KEY = "ancestorModels";
+    static final String PARENT_MODELS_KEY = "parentModels";
 
     private static final List<String> CONFIG_FILE_NAMES = List.of(
             RuneConfigurationFileProvider.FILE_NAME,
@@ -131,7 +134,7 @@ public final class DefaultModelSerialisation {
      * {@code classLoader}, consulting its {@value #MODEL_PROPERTIES_PATH} marker. When several models
      * (and hence markers) are on the classpath, the winner is elected by ancestry — the leaf marker,
      * i.e. the one whose {@value #MODEL_ID_KEY} appears in no other marker's
-     * {@value #ANCESTOR_MODELS_KEY} — independent of classpath order. If any marker predates the
+     * {@value #PARENT_MODELS_KEY} — independent of classpath order. If any marker predates the
      * ancestry keys, the first marker in classpath order wins instead (compatibility fallback).
      *
      * @throws IllegalStateException if no marker is found on the classpath (this {@code rune-testing}
@@ -232,15 +235,15 @@ public final class DefaultModelSerialisation {
             return modelId == null || modelId.isBlank() ? null : modelId.trim();
         }
 
-        /** The identities of all the model's ancestors; empty for a root model or a pre-ancestry marker. */
-        Set<String> ancestorModels() {
-            String ancestorModels = properties.getProperty(ANCESTOR_MODELS_KEY);
-            if (ancestorModels == null || ancestorModels.isBlank()) {
+        /** The identities of the model's direct parents; empty for a root model or a pre-ancestry marker. */
+        Set<String> parentModels() {
+            String parentModels = properties.getProperty(PARENT_MODELS_KEY);
+            if (parentModels == null || parentModels.isBlank()) {
                 return Set.of();
             }
-            return Arrays.stream(ancestorModels.split(","))
+            return Arrays.stream(parentModels.split(","))
                     .map(String::trim)
-                    .filter(ancestor -> !ancestor.isEmpty())
+                    .filter(parent -> !parent.isEmpty())
                     .collect(Collectors.toSet());
         }
 
@@ -276,13 +279,14 @@ public final class DefaultModelSerialisation {
 
     /**
      * Elects the winning marker: the <em>leaf</em> of the model graph, i.e. the marker whose
-     * {@code modelId} appears in no other marker's {@code ancestorModels} (exact, case-sensitive GA
+     * {@code modelId} appears in no other marker's {@code parentModels} (exact, case-sensitive GA
      * comparison). Falls back to classpath order when any marker predates the ancestry keys (so models
      * built with a pre-ancestry rune-maven-plugin keep working) and, with a warning, when no leaf
      * exists (an ancestry cycle, only possible via corrupted markers — a malformed marker must not
      * block a build). Several markers agreeing on one {@code modelId} (the same model twice on the
      * classpath) are one leaf, resolved by classpath order; leaves with <em>different</em> identities
-     * are two independent model graphs, which is genuinely ambiguous and fails loudly.
+     * fail loudly — either two independent model graphs (genuinely ambiguous) or an intermediate
+     * model jar without a marker, whose edge would have ruled its parent out.
      */
     private static Marker electWinner(List<Marker> markers) {
         if (markers.stream().anyMatch(marker -> marker.modelId() == null)) {
@@ -293,10 +297,10 @@ public final class DefaultModelSerialisation {
         }
         List<Marker> leaves = markers.stream()
                 .filter(candidate -> markers.stream()
-                        .noneMatch(other -> other != candidate && other.ancestorModels().contains(candidate.modelId())))
+                        .noneMatch(other -> other != candidate && other.parentModels().contains(candidate.modelId())))
                 .collect(Collectors.toList());
         if (leaves.isEmpty()) {
-            LOGGER.warn("No leaf model found among the {} markers on the classpath - their ancestorModels "
+            LOGGER.warn("No leaf model found among the {} markers on the classpath - their parentModels "
                     + "declarations form a cycle, which can only come from corrupted markers. Falling back to "
                     + "the first marker in classpath order.", MODEL_PROPERTIES_PATH);
             return markers.get(0);
@@ -305,10 +309,13 @@ public final class DefaultModelSerialisation {
         if (distinctLeafIds > 1) {
             String leafNames = leaves.stream().map(Marker::displayName).collect(Collectors.joining(", "));
             throw new IllegalStateException("Multiple independent leaf models found on the test classpath: "
-                    + leafNames + ". None of them is an ancestor of another, so there is no single \"model "
-                    + "under test\" to resolve the default serialisation for. Remove the unrelated model from "
-                    + "the classpath, or declare the missing ancestry via rosetta.parent.* properties in the "
-                    + "child model's top-level pom and rebuild it.");
+                    + leafNames + ". None of them is a parent of another, so there is no single \"model "
+                    + "under test\" to resolve the default serialisation for. Either two unrelated models are "
+                    + "on one classpath (remove the one that does not belong, or declare the missing ancestry "
+                    + "via rosetta.parent.* properties in the child model's top-level pom and rebuild it), or "
+                    + "an intermediate model jar between them carries no marker - a model that declares a "
+                    + "parent must be built with a marker-writing rune-maven-plugin; rebuild that intermediate "
+                    + "model.");
         }
         return leaves.get(0);
     }

--- a/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
+++ b/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
@@ -32,8 +32,10 @@ import org.finos.rune.mapper.RuneJsonObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -169,15 +171,28 @@ public final class DefaultModelSerialisation {
         String markerUrlString = markerUrl.toExternalForm();
         String containerBase = markerUrlString.substring(0, markerUrlString.length() - MODEL_PROPERTIES_PATH.length());
         for (String fileName : CONFIG_FILE_NAMES) {
+            String candidateUrlString = containerBase + fileName;
+            URL candidate;
             try {
-                URL candidate = new URI(containerBase + fileName).toURL();
-                try (InputStream in = candidate.openStream()) {
-                    return Optional.of(candidate);
+                candidate = new URI(candidateUrlString).toURL();
+            } catch (URISyntaxException | MalformedURLException e) {
+                // Unexpected: containerBase was itself derived from a URL, so this would mean the classpath
+                // entry's URL isn't validly-encoded (e.g. an unencoded space) - log it rather than silently
+                // falling through, since that would otherwise look identical to "file not present".
+                LOGGER.error("Could not build a valid URI from {}, skipping this candidate config location",
+                        candidateUrlString, e);
+                continue;
+            }
+            try (InputStream ignored = candidate.openStream()) {
+                return Optional.of(candidate);
+            } catch (FileNotFoundException e) {
+                if (fileName.equals(RuneConfigurationFileProvider.LEGACY_FILE_NAME)) {
+                    LOGGER.error("{} not present either, no config found in this container", candidate);
+                } else {
+                    LOGGER.warn("{} not present in this container, trying the legacy candidate name", candidate);
                 }
-            } catch (URISyntaxException | IOException e) {
-                // Not present in this container (or, for URISyntaxException, containerBase + fileName isn't a
-                // validly-encoded URI - e.g. an unencoded space from a classpath entry on a path containing one);
-                // either way, try the next name.
+            } catch (IOException e) {
+                LOGGER.error("Failed to open candidate config location {}, skipping", candidate, e);
             }
         }
         return Optional.empty();

--- a/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
+++ b/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
@@ -39,11 +39,15 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Resolves the default JSON serialisation (mapper + writer) for a transform side that carries no
@@ -60,13 +64,16 @@ import java.util.Properties;
  * model that ships no config of its own could otherwise silently pick up an ancestor's and adopt its
  * default. Instead, {@code rune-maven-plugin} writes a per-model marker,
  * {@value #MODEL_PROPERTIES_PATH}, recording whether that model ships its own config
- * ({@value #RUNE_CONFIG_PRESENT_IN_MODEL_KEY}). The marker is looked up once via
- * {@link ClassLoader#getResource(String)} (first on classpath order, matching a model's own {@code tests}
- * module resolving to its own marker ahead of a dependency's), and its answer is authoritative: if it
- * says {@code false}, no config is looked up at all, even if one happens to be reachable via a dependency.
- * If it says {@code true}, the config is resolved relative to the marker's own container (its own jar or
- * exploded classes directory), never via a second classpath-order lookup that could resolve to a
- * different container.
+ * ({@value #RUNE_CONFIG_PRESENT_IN_MODEL_KEY}), the model's repo identity ({@value #MODEL_ID_KEY}) and
+ * the closure of its ancestor models' identities ({@value #ANCESTOR_MODELS_KEY}). All markers on the
+ * classpath are enumerated and the <em>leaf</em> is elected — the marker whose {@code modelId} no other
+ * marker claims among its {@code ancestorModels} — so the winner is computed from the model graph
+ * itself, independent of classpath order. If any marker predates the ancestry keys (no
+ * {@code modelId}), election is skipped and the first marker in classpath order wins, keeping older
+ * model builds working. The winning marker's answer is authoritative: if it says the config is absent,
+ * no config is looked up at all, even if one happens to be reachable via a dependency; if present, the
+ * config is resolved relative to the marker's own container (its own jar or exploded classes
+ * directory), never via a second classpath-order lookup that could resolve to a different container.
  */
 public final class DefaultModelSerialisation {
 
@@ -76,6 +83,9 @@ public final class DefaultModelSerialisation {
     static final String MODEL_PROPERTIES_PATH = "META-INF/rune/model.properties";
     static final String RUNE_CONFIG_PRESENT_IN_MODEL_KEY = "runeConfigPresentInModel";
     static final String RUNE_MAVEN_PLUGIN_VERSION_KEY = "runeMavenPluginVersion";
+    static final String MODEL_SOURCE_GAV_KEY = "modelSourceGav";
+    static final String MODEL_ID_KEY = "modelId";
+    static final String ANCESTOR_MODELS_KEY = "ancestorModels";
 
     private static final List<String> CONFIG_FILE_NAMES = List.of(
             RuneConfigurationFileProvider.FILE_NAME,
@@ -118,36 +128,45 @@ public final class DefaultModelSerialisation {
 
     /**
      * Resolves the default mapper for the model whose configuration is discoverable on
-     * {@code classLoader}, consulting its {@value #MODEL_PROPERTIES_PATH} marker.
+     * {@code classLoader}, consulting its {@value #MODEL_PROPERTIES_PATH} marker. When several models
+     * (and hence markers) are on the classpath, the winner is elected by ancestry — the leaf marker,
+     * i.e. the one whose {@value #MODEL_ID_KEY} appears in no other marker's
+     * {@value #ANCESTOR_MODELS_KEY} — independent of classpath order. If any marker predates the
+     * ancestry keys, the first marker in classpath order wins instead (compatibility fallback).
      *
      * @throws IllegalStateException if no marker is found on the classpath (this {@code rune-testing}
-     *         requires a marker that an older {@code rune-maven-plugin} does not produce), if the marker
-     *         declares the config present but neither config file is found in its own container, if an
-     *         ancestor's marker declares a newer {@code runeMavenPluginVersion} than the winning marker's
-     *         (violating the convention that a child's dsl/bundle version is always ≥ its parent's), or if
-     *         the configured format is anything other than {@code JSON}/{@code RUNE_JSON} — the backend
-     *         honours any {@link SerializationFormat}, but the test harness only mirrors the two JSON
-     *         flavours today, so any other value would otherwise silently fall back to the legacy mapper
-     *         and diverge from the runtime default.
+     *         requires a marker that an older {@code rune-maven-plugin} does not produce), if leaf
+     *         election finds several independent leaves (two unrelated model graphs on one test
+     *         classpath is genuinely ambiguous), if the winning marker declares the config present but
+     *         neither config file is found in its own container, if another marker declares a newer
+     *         {@code runeMavenPluginVersion} than the winning marker's (violating the convention that a
+     *         child's dsl/bundle version is always ≥ its parent's), or if the configured format is
+     *         anything other than {@code JSON}/{@code RUNE_JSON} — the backend honours any
+     *         {@link SerializationFormat}, but the test harness only mirrors the two JSON flavours
+     *         today, so any other value would otherwise silently fall back to the legacy mapper and
+     *         diverge from the runtime default.
      */
     public static DefaultModelSerialisation resolve(ClassLoader classLoader) {
         Objects.requireNonNull(classLoader, "classLoader must not be null");
-        URL markerUrl = classLoader.getResource(MODEL_PROPERTIES_PATH);
-        if (markerUrl == null) {
+        List<Marker> markers = readAllMarkers(classLoader);
+        if (markers.isEmpty()) {
             throw new IllegalStateException("No " + MODEL_PROPERTIES_PATH + " marker found on the classpath. "
                     + "rune-maven-plugin and rune-testing move together as a pair: this model was built with a "
                     + "rune-maven-plugin version that predates the marker (or the marker's generate execution is "
                     + "missing), while this rune-testing version requires it to be present. Rebuild the model "
                     + "with a matching rune-maven-plugin version.");
         }
-        checkPluginVersionConvention(classLoader, markerUrl);
-        Properties markerProperties = readProperties(markerUrl);
-        boolean configPresent = Boolean.parseBoolean(markerProperties.getProperty(RUNE_CONFIG_PRESENT_IN_MODEL_KEY));
+        Marker winner = electWinner(markers);
+        LOGGER.info("Resolving default serialisation from marker of {} (modelId {})", winner.displayName(),
+                winner.modelId() == null ? "unknown" : winner.modelId());
+        checkPluginVersionConvention(markers, winner);
+        URL markerUrl = winner.url();
+        boolean configPresent = Boolean.parseBoolean(winner.properties().getProperty(RUNE_CONFIG_PRESENT_IN_MODEL_KEY));
         if (!configPresent) {
             return new DefaultModelSerialisation(RosettaObjectMapper.getNewRosettaObjectMapper(), false);
         }
         URL configUrl = resolveConfigUrlInContainer(markerUrl)
-                .orElseThrow(() -> new IllegalStateException("Model config marker at " + markerUrl + " declares "
+                .orElseThrow(() -> new IllegalStateException("Model config marker of " + winner.displayName() + " declares "
                         + RUNE_CONFIG_PRESENT_IN_MODEL_KEY + "=true, but neither " + RuneConfigurationFileProvider.FILE_NAME
                         + " nor " + RuneConfigurationFileProvider.LEGACY_FILE_NAME + " was found alongside it in the "
                         + "same container. This indicates a broken build."));
@@ -202,38 +221,122 @@ public final class DefaultModelSerialisation {
     }
 
     /**
+     * A parsed {@value #MODEL_PROPERTIES_PATH} marker. Markers keep classpath enumeration order, which
+     * remains the tie-breaking/fallback order wherever leaf election cannot decide.
+     */
+    private record Marker(URL url, Properties properties) {
+
+        /** The model's repo identity ({@code groupId:artifactId}); {@code null} on pre-ancestry markers. */
+        String modelId() {
+            String modelId = properties.getProperty(MODEL_ID_KEY);
+            return modelId == null || modelId.isBlank() ? null : modelId.trim();
+        }
+
+        /** The identities of all the model's ancestors; empty for a root model or a pre-ancestry marker. */
+        Set<String> ancestorModels() {
+            String ancestorModels = properties.getProperty(ANCESTOR_MODELS_KEY);
+            if (ancestorModels == null || ancestorModels.isBlank()) {
+                return Set.of();
+            }
+            return Arrays.stream(ancestorModels.split(","))
+                    .map(String::trim)
+                    .filter(ancestor -> !ancestor.isEmpty())
+                    .collect(Collectors.toSet());
+        }
+
+        /** Names the marker in log/error text: the real artifact when recorded, the URL otherwise. */
+        String displayName() {
+            String modelSourceGav = properties.getProperty(MODEL_SOURCE_GAV_KEY);
+            return modelSourceGav == null || modelSourceGav.isBlank() ? url.toExternalForm() : modelSourceGav.trim();
+        }
+    }
+
+    /**
+     * Enumerates and parses every marker on the classpath, in classpath order. Should enumeration
+     * itself fail (an IO problem, not a malformed marker), degrades to the single
+     * {@link ClassLoader#getResource(String)} lookup with a warning rather than failing resolution.
+     */
+    private static List<Marker> readAllMarkers(ClassLoader classLoader) {
+        List<URL> urls = new ArrayList<>();
+        try {
+            Enumeration<URL> resources = classLoader.getResources(MODEL_PROPERTIES_PATH);
+            while (resources.hasMoreElements()) {
+                urls.add(resources.nextElement());
+            }
+        } catch (IOException e) {
+            LOGGER.warn("Failed to enumerate {} markers on the classpath; falling back to the first marker "
+                    + "in classpath order", MODEL_PROPERTIES_PATH, e);
+            URL single = classLoader.getResource(MODEL_PROPERTIES_PATH);
+            if (single != null) {
+                urls.add(single);
+            }
+        }
+        return urls.stream().map(url -> new Marker(url, readProperties(url))).collect(Collectors.toList());
+    }
+
+    /**
+     * Elects the winning marker: the <em>leaf</em> of the model graph, i.e. the marker whose
+     * {@code modelId} appears in no other marker's {@code ancestorModels} (exact, case-sensitive GA
+     * comparison). Falls back to classpath order when any marker predates the ancestry keys (so models
+     * built with a pre-ancestry rune-maven-plugin keep working) and, with a warning, when no leaf
+     * exists (an ancestry cycle, only possible via corrupted markers — a malformed marker must not
+     * block a build). Several markers agreeing on one {@code modelId} (the same model twice on the
+     * classpath) are one leaf, resolved by classpath order; leaves with <em>different</em> identities
+     * are two independent model graphs, which is genuinely ambiguous and fails loudly.
+     */
+    private static Marker electWinner(List<Marker> markers) {
+        if (markers.stream().anyMatch(marker -> marker.modelId() == null)) {
+            LOGGER.debug("Leaf election skipped: a marker without {} (written by a pre-ancestry "
+                    + "rune-maven-plugin) is on the classpath; falling back to the first marker in classpath "
+                    + "order", MODEL_ID_KEY);
+            return markers.get(0);
+        }
+        List<Marker> leaves = markers.stream()
+                .filter(candidate -> markers.stream()
+                        .noneMatch(other -> other != candidate && other.ancestorModels().contains(candidate.modelId())))
+                .collect(Collectors.toList());
+        if (leaves.isEmpty()) {
+            LOGGER.warn("No leaf model found among the {} markers on the classpath - their ancestorModels "
+                    + "declarations form a cycle, which can only come from corrupted markers. Falling back to "
+                    + "the first marker in classpath order.", MODEL_PROPERTIES_PATH);
+            return markers.get(0);
+        }
+        long distinctLeafIds = leaves.stream().map(Marker::modelId).distinct().count();
+        if (distinctLeafIds > 1) {
+            String leafNames = leaves.stream().map(Marker::displayName).collect(Collectors.joining(", "));
+            throw new IllegalStateException("Multiple independent leaf models found on the test classpath: "
+                    + leafNames + ". None of them is an ancestor of another, so there is no single \"model "
+                    + "under test\" to resolve the default serialisation for. Remove the unrelated model from "
+                    + "the classpath, or declare the missing ancestry via rosetta.parent.* properties in the "
+                    + "child model's top-level pom and rebuild it.");
+        }
+        return leaves.get(0);
+    }
+
+    /**
      * Verifies the team convention that a child model's dsl/bundle version is always ≥ its parent's, which
      * is what makes marker presence monotonic in plugin version and rules out a marker-less child sitting
-     * under a marked ancestor. Enumerates every marker on the classpath and fails if any *other* one
-     * declares a {@value #RUNE_MAVEN_PLUGIN_VERSION_KEY} greater than the winning marker's. A missing or
+     * under a marked ancestor. Fails if any *other* marker declares a
+     * {@value #RUNE_MAVEN_PLUGIN_VERSION_KEY} greater than the winning marker's. A missing or
      * unparseable version on either side skips that comparison rather than failing the build, so a
-     * malformed marker cannot block it.
+     * malformed marker cannot block it. Orthogonal to leaf election: this detects version skew, election
+     * detects order skew.
      */
-    private static void checkPluginVersionConvention(ClassLoader classLoader, URL winningMarkerUrl) {
-        ComparableVersion winningVersion = parseVersion(
-                readProperties(winningMarkerUrl).getProperty(RUNE_MAVEN_PLUGIN_VERSION_KEY));
+    private static void checkPluginVersionConvention(List<Marker> markers, Marker winner) {
+        ComparableVersion winningVersion = parseVersion(winner.properties().getProperty(RUNE_MAVEN_PLUGIN_VERSION_KEY));
         if (winningVersion == null) {
             return;
         }
-        Enumeration<URL> allMarkers;
-        try {
-            allMarkers = classLoader.getResources(MODEL_PROPERTIES_PATH);
-        } catch (IOException e) {
-            LOGGER.warn("Failed to enumerate {} markers on the classpath, skipping the plugin version "
-                    + "convention check", MODEL_PROPERTIES_PATH, e);
-            return;
-        }
-        while (allMarkers.hasMoreElements()) {
-            URL markerUrl = allMarkers.nextElement();
-            if (markerUrl.toExternalForm().equals(winningMarkerUrl.toExternalForm())) {
+        for (Marker marker : markers) {
+            if (marker == winner) {
                 continue;
             }
-            String otherVersionString = readProperties(markerUrl).getProperty(RUNE_MAVEN_PLUGIN_VERSION_KEY);
+            String otherVersionString = marker.properties().getProperty(RUNE_MAVEN_PLUGIN_VERSION_KEY);
             ComparableVersion otherVersion = parseVersion(otherVersionString);
             if (otherVersion != null && otherVersion.compareTo(winningVersion) > 0) {
-                throw new IllegalStateException("Model config marker at " + markerUrl + " declares "
+                throw new IllegalStateException("Model config marker of " + marker.displayName() + " declares "
                         + RUNE_MAVEN_PLUGIN_VERSION_KEY + "=" + otherVersionString + ", newer than the winning "
-                        + "marker's " + winningMarkerUrl + " (version " + winningVersion + "). The team "
+                        + "marker's (" + winner.displayName() + ", version " + winningVersion + "). The team "
                         + "convention that a child model's rune dsl/bundle version is always >= its parent's has "
                         + "been violated.");
             }

--- a/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
+++ b/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
@@ -27,14 +27,21 @@ import com.regnosys.rosetta.common.serialisation.RosettaObjectMapper;
 import com.regnosys.rosetta.config.RuneConfigurationService;
 import com.regnosys.rosetta.config.file.RuneConfigurationFileProvider;
 import com.rosetta.model.lib.transform.SerializationFormat;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.finos.rune.mapper.RuneJsonObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 
 /**
  * Resolves the default JSON serialisation (mapper + writer) for a transform side that carries no
@@ -47,16 +54,27 @@ import java.util.Optional;
  * as the Rosetta runtime does. A missing config file, an absent field, or a parse failure all fall back
  * to the legacy mapper, so a model that does not opt in keeps today's behaviour unchanged.
  * <p>
- * The model config is looked up as a classpath resource via the supplied {@link ClassLoader} — the model
- * lives on the application/test classpath here, unlike the products side, which reads from a resolved
- * workspace/jar base path. A dependency model on the same classpath may also ship a config file;
- * {@link ClassLoader#getResource(String)} returns the first on classpath order, which for a model's own
- * {@code tests} module is its own resources.
+ * Which model actually "owns" the config is no longer inferred from classpath resource order — a child
+ * model that ships no config of its own could otherwise silently pick up an ancestor's and adopt its
+ * default. Instead, {@code rune-maven-plugin} writes a per-model marker,
+ * {@value #MODEL_PROPERTIES_PATH}, recording whether that model ships its own config
+ * ({@value #RUNE_CONFIG_PRESENT_IN_MODEL_KEY}). The marker is looked up once via
+ * {@link ClassLoader#getResource(String)} (first on classpath order, matching a model's own {@code tests}
+ * module resolving to its own marker ahead of a dependency's), and its answer is authoritative: if it
+ * says {@code false}, no config is looked up at all, even if one happens to be reachable via a dependency.
+ * If it says {@code true}, the config is resolved relative to the marker's own container (its own jar or
+ * exploded classes directory), never via a second classpath-order lookup that could resolve to a
+ * different container.
  */
 public final class DefaultModelSerialisation {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultModelSerialisation.class);
     private static final RuneConfigurationService RUNE_CONFIGURATION_SERVICE = new RuneConfigurationService();
+
+    static final String MODEL_PROPERTIES_PATH = "META-INF/rune/model.properties";
+    static final String RUNE_CONFIG_PRESENT_IN_MODEL_KEY = "runeConfigPresentInModel";
+    static final String RUNE_MAVEN_PLUGIN_VERSION_KEY = "runeMavenPluginVersion";
+
     private static final List<String> CONFIG_FILE_NAMES = List.of(
             RuneConfigurationFileProvider.FILE_NAME,
             RuneConfigurationFileProvider.LEGACY_FILE_NAME);
@@ -95,16 +113,40 @@ public final class DefaultModelSerialisation {
 
     /**
      * Resolves the default mapper for the model whose configuration is discoverable on
-     * {@code classLoader}.
+     * {@code classLoader}, consulting its {@value #MODEL_PROPERTIES_PATH} marker.
      *
-     * @throws IllegalStateException if the configured format is anything other than
-     *         {@code JSON}/{@code RUNE_JSON} — the backend honours any {@link SerializationFormat}, but
-     *         the test harness only mirrors the two JSON flavours today, so any other value would
-     *         otherwise silently fall back to the legacy mapper and diverge from the runtime default.
+     * @throws IllegalStateException if no marker is found on the classpath (this {@code rune-testing}
+     *         requires a marker that an older {@code rune-maven-plugin} does not produce), if the marker
+     *         declares the config present but neither config file is found in its own container, if an
+     *         ancestor's marker declares a newer {@code runeMavenPluginVersion} than the winning marker's
+     *         (violating the convention that a child's dsl/bundle version is always ≥ its parent's), or if
+     *         the configured format is anything other than {@code JSON}/{@code RUNE_JSON} — the backend
+     *         honours any {@link SerializationFormat}, but the test harness only mirrors the two JSON
+     *         flavours today, so any other value would otherwise silently fall back to the legacy mapper
+     *         and diverge from the runtime default.
      */
     public static DefaultModelSerialisation resolve(ClassLoader classLoader) {
         Objects.requireNonNull(classLoader, "classLoader must not be null");
-        Optional<SerializationFormat> defaultFormat = readDefaultSerialisationFormat(classLoader);
+        URL markerUrl = classLoader.getResource(MODEL_PROPERTIES_PATH);
+        if (markerUrl == null) {
+            throw new IllegalStateException("No " + MODEL_PROPERTIES_PATH + " marker found on the classpath. "
+                    + "rune-maven-plugin and rune-testing move together as a pair: this model was built with a "
+                    + "rune-maven-plugin version that predates the marker (or the marker's generate execution is "
+                    + "missing), while this rune-testing version requires it to be present. Rebuild the model "
+                    + "with a matching rune-maven-plugin version.");
+        }
+        checkPluginVersionConvention(classLoader, markerUrl);
+        Properties markerProperties = readProperties(markerUrl);
+        boolean configPresent = Boolean.parseBoolean(markerProperties.getProperty(RUNE_CONFIG_PRESENT_IN_MODEL_KEY));
+        if (!configPresent) {
+            return new DefaultModelSerialisation(RosettaObjectMapper.getNewRosettaObjectMapper(), false);
+        }
+        URL configUrl = resolveConfigUrlInContainer(markerUrl)
+                .orElseThrow(() -> new IllegalStateException("Model config marker at " + markerUrl + " declares "
+                        + RUNE_CONFIG_PRESENT_IN_MODEL_KEY + "=true, but neither " + RuneConfigurationFileProvider.FILE_NAME
+                        + " nor " + RuneConfigurationFileProvider.LEGACY_FILE_NAME + " was found alongside it in the "
+                        + "same container. This indicates a broken build."));
+        Optional<SerializationFormat> defaultFormat = readDefaultSerialisationFormat(configUrl);
         if (defaultFormat.isEmpty() || defaultFormat.get() == SerializationFormat.JSON) {
             return new DefaultModelSerialisation(RosettaObjectMapper.getNewRosettaObjectMapper(), false);
         }
@@ -117,19 +159,88 @@ public final class DefaultModelSerialisation {
                 + "runtime default.");
     }
 
-    private static Optional<SerializationFormat> readDefaultSerialisationFormat(ClassLoader classLoader) {
-        return findConfigUrl(classLoader).flatMap(DefaultModelSerialisation::readDefaultSerialisationFormat);
+    /**
+     * Resolves the config file relative to the marker's own container: strips {@value #MODEL_PROPERTIES_PATH}
+     * off the marker URL and probes {@code rune-config.yml}, then {@code rosetta-config.yml}, alongside it.
+     * Works for both {@code jar:file:/…!/} and exploded {@code file:/…/target/classes/} URL forms, since in
+     * both the marker's classpath-relative path is a literal suffix of the marker's URL.
+     */
+    private static Optional<URL> resolveConfigUrlInContainer(URL markerUrl) {
+        String markerUrlString = markerUrl.toExternalForm();
+        String containerBase = markerUrlString.substring(0, markerUrlString.length() - MODEL_PROPERTIES_PATH.length());
+        for (String fileName : CONFIG_FILE_NAMES) {
+            try {
+                URL candidate = new URI(containerBase + fileName).toURL();
+                try (InputStream in = candidate.openStream()) {
+                    return Optional.of(candidate);
+                }
+            } catch (URISyntaxException | IOException e) {
+                // Not present in this container (or, for URISyntaxException, containerBase + fileName isn't a
+                // validly-encoded URI - e.g. an unencoded space from a classpath entry on a path containing one);
+                // either way, try the next name.
+            }
+        }
+        return Optional.empty();
     }
 
-    // TODO: use a path to the config which could be configured as a maven property, so this code could
-    // read that property to know which config to use - the rune-maven-plugin and rosetta-maven-plugin
-    // could also reference the same pom property, giving a single source of truth for parent/child models
-    // on the same classpath instead of relying on classpath resource order.
-    private static Optional<URL> findConfigUrl(ClassLoader classLoader) {
-        return CONFIG_FILE_NAMES.stream()
-                .map(classLoader::getResource)
-                .filter(Objects::nonNull)
-                .findFirst();
+    /**
+     * Verifies the team convention that a child model's dsl/bundle version is always ≥ its parent's, which
+     * is what makes marker presence monotonic in plugin version and rules out a marker-less child sitting
+     * under a marked ancestor. Enumerates every marker on the classpath and fails if any *other* one
+     * declares a {@value #RUNE_MAVEN_PLUGIN_VERSION_KEY} greater than the winning marker's. A missing or
+     * unparseable version on either side skips that comparison rather than failing the build, so a
+     * malformed marker cannot block it.
+     */
+    private static void checkPluginVersionConvention(ClassLoader classLoader, URL winningMarkerUrl) {
+        ComparableVersion winningVersion = parseVersion(
+                readProperties(winningMarkerUrl).getProperty(RUNE_MAVEN_PLUGIN_VERSION_KEY));
+        if (winningVersion == null) {
+            return;
+        }
+        Enumeration<URL> allMarkers;
+        try {
+            allMarkers = classLoader.getResources(MODEL_PROPERTIES_PATH);
+        } catch (IOException e) {
+            LOGGER.warn("Failed to enumerate {} markers on the classpath, skipping the plugin version "
+                    + "convention check", MODEL_PROPERTIES_PATH, e);
+            return;
+        }
+        while (allMarkers.hasMoreElements()) {
+            URL markerUrl = allMarkers.nextElement();
+            if (markerUrl.toExternalForm().equals(winningMarkerUrl.toExternalForm())) {
+                continue;
+            }
+            String otherVersionString = readProperties(markerUrl).getProperty(RUNE_MAVEN_PLUGIN_VERSION_KEY);
+            ComparableVersion otherVersion = parseVersion(otherVersionString);
+            if (otherVersion != null && otherVersion.compareTo(winningVersion) > 0) {
+                throw new IllegalStateException("Model config marker at " + markerUrl + " declares "
+                        + RUNE_MAVEN_PLUGIN_VERSION_KEY + "=" + otherVersionString + ", newer than the winning "
+                        + "marker's " + winningMarkerUrl + " (version " + winningVersion + "). The team "
+                        + "convention that a child model's rune dsl/bundle version is always >= its parent's has "
+                        + "been violated.");
+            }
+        }
+    }
+
+    private static ComparableVersion parseVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return null;
+        }
+        try {
+            return new ComparableVersion(version);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static Properties readProperties(URL url) {
+        Properties properties = new Properties();
+        try (InputStream in = url.openStream()) {
+            properties.load(in);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read model properties marker at " + url, e);
+        }
+        return properties;
     }
 
     private static Optional<SerializationFormat> readDefaultSerialisationFormat(URL configUrl) {

--- a/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
+++ b/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
@@ -293,17 +293,17 @@ public final class DefaultModelSerialisation {
             LOGGER.debug("Leaf election skipped: a marker without {} (written by a pre-ancestry "
                     + "rune-maven-plugin) is on the classpath; falling back to the first marker in classpath "
                     + "order", MODEL_ID_KEY);
-            return markers.get(0);
+            return markers.getFirst();
         }
         List<Marker> leaves = markers.stream()
                 .filter(candidate -> markers.stream()
                         .noneMatch(other -> other != candidate && other.parentModels().contains(candidate.modelId())))
-                .collect(Collectors.toList());
+                .toList();
         if (leaves.isEmpty()) {
             LOGGER.warn("No leaf model found among the {} markers on the classpath - their parentModels "
                     + "declarations form a cycle, which can only come from corrupted markers. Falling back to "
                     + "the first marker in classpath order.", MODEL_PROPERTIES_PATH);
-            return markers.get(0);
+            return markers.getFirst();
         }
         long distinctLeafIds = leaves.stream().map(Marker::modelId).distinct().count();
         if (distinctLeafIds > 1) {
@@ -317,7 +317,7 @@ public final class DefaultModelSerialisation {
                     + "parent must be built with a marker-writing rune-maven-plugin; rebuild that intermediate "
                     + "model.");
         }
-        return leaves.get(0);
+        return leaves.getFirst();
     }
 
     /**

--- a/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
+++ b/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
@@ -108,7 +108,10 @@ public final class DefaultModelSerialisation {
      */
     public ObjectWriter createWriter(boolean sortJsonPropertiesAlphabetically) {
         if (!runeJson) {
-            objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, sortJsonPropertiesAlphabetically);
+            objectMapper.setConfig(objectMapper.getSerializationConfig()
+                    .with(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, sortJsonPropertiesAlphabetically));
+            objectMapper.setConfig(objectMapper.getDeserializationConfig()
+                    .with(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, sortJsonPropertiesAlphabetically));
         }
         return objectMapper.writerWithDefaultPrettyPrinter();
     }

--- a/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
+++ b/src/main/java/com/regnosys/testing/serialisation/DefaultModelSerialisation.java
@@ -137,10 +137,11 @@ public final class DefaultModelSerialisation {
      * {@value #PARENT_MODELS_KEY} — independent of classpath order. If any marker predates the
      * ancestry keys, the first marker in classpath order wins instead (compatibility fallback).
      *
-     * @throws IllegalStateException if no marker is found on the classpath (this {@code rune-testing}
-     *         requires a marker that an older {@code rune-maven-plugin} does not produce), if leaf
-     *         election finds several independent leaves (two unrelated model graphs on one test
-     *         classpath is genuinely ambiguous), if the winning marker declares the config present but
+     * @throws IllegalStateException if the markers cannot be enumerated or read at all (an IO failure
+     *         reading the classpath itself), if no marker is found on the classpath (this
+     *         {@code rune-testing} requires a marker that an older {@code rune-maven-plugin} does not
+     *         produce), if leaf election finds several independent leaves (two unrelated model graphs on
+     *         one test classpath is genuinely ambiguous), if the winning marker declares the config present but
      *         neither config file is found in its own container, if another marker declares a newer
      *         {@code runeMavenPluginVersion} than the winning marker's (violating the convention that a
      *         child's dsl/bundle version is always ≥ its parent's), or if the configured format is
@@ -255,9 +256,13 @@ public final class DefaultModelSerialisation {
     }
 
     /**
-     * Enumerates and parses every marker on the classpath, in classpath order. Should enumeration
-     * itself fail (an IO problem, not a malformed marker), degrades to the single
-     * {@link ClassLoader#getResource(String)} lookup with a warning rather than failing resolution.
+     * Enumerates and parses every marker on the classpath, in classpath order. Enumeration failing is an
+     * IO problem with the classpath itself, not a malformed marker: it fails loudly, matching
+     * {@link #readProperties(URL)}. Degrading to the single {@link ClassLoader#getResource(String)}
+     * lookup instead would reinstate the classpath-order semantics this marker exists to replace, and so
+     * could silently elect an ancestor's marker — the original bug, in a harder place to spot. The
+     * classpath-order fallback is therefore reached only from {@link #electWinner(List)}, for the
+     * deliberate pre-ancestry-marker and corrupted-ancestry cases.
      */
     private static List<Marker> readAllMarkers(ClassLoader classLoader) {
         List<URL> urls = new ArrayList<>();
@@ -267,12 +272,9 @@ public final class DefaultModelSerialisation {
                 urls.add(resources.nextElement());
             }
         } catch (IOException e) {
-            LOGGER.warn("Failed to enumerate {} markers on the classpath; falling back to the first marker "
-                    + "in classpath order", MODEL_PROPERTIES_PATH, e);
-            URL single = classLoader.getResource(MODEL_PROPERTIES_PATH);
-            if (single != null) {
-                urls.add(single);
-            }
+            throw new IllegalStateException("Failed to enumerate " + MODEL_PROPERTIES_PATH + " markers on the "
+                    + "classpath. This is an IO failure reading the classpath itself, not a malformed marker - "
+                    + "check for an unreadable or corrupt jar or classes directory on the test classpath.", e);
         }
         return urls.stream().map(url -> new Marker(url, readProperties(url))).collect(Collectors.toList());
     }

--- a/src/test/java/com/regnosys/testing/serialisation/DefaultModelSerialisationTest.java
+++ b/src/test/java/com/regnosys/testing/serialisation/DefaultModelSerialisationTest.java
@@ -357,6 +357,37 @@ class DefaultModelSerialisationTest {
     }
 
     @Test
+    void grandparentIsRuledOutByTheIntermediatesMarkerNotTheLeafs() throws IOException {
+        // Three-model chain (root -> middle -> leaf), root's marker first on the classpath. The
+        // leaf's parentModels name only the middle model; the edge that rules the root out comes
+        // from the middle model's own marker - the property direct-parents election relies on.
+        Path rootContainer = Files.createDirectories(tempDir.resolve("root"));
+        Path middleContainer = Files.createDirectories(tempDir.resolve("middle"));
+        Path leafContainer = Files.createDirectories(tempDir.resolve("leaf"));
+        Files.writeString(rootContainer.resolve("rune-config.yml"), """
+                model:
+                  name: Root Model
+                  defaultSerialisationFormat: JSON
+                """, StandardCharsets.UTF_8);
+        writeAncestryMarker(rootContainer, true, DEFAULT_VERSION,
+                "org.example:root-java:1.0.0", "org.example:root-parent", "");
+        writeAncestryMarker(middleContainer, false, DEFAULT_VERSION,
+                "org.example:middle-java:1.0.0", "org.example:middle-parent", "org.example:root-parent");
+        Files.writeString(leafContainer.resolve("rune-config.yml"), """
+                model:
+                  name: Leaf Model
+                  defaultSerialisationFormat: RUNE_JSON
+                """, StandardCharsets.UTF_8);
+        writeAncestryMarker(leafContainer, true, DEFAULT_VERSION,
+                "org.example:leaf-java:1.0.0", "org.example:leaf-parent", "org.example:middle-parent");
+
+        DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(
+                containersClassLoader(rootContainer, middleContainer, leafContainer));
+
+        assertInstanceOf(RuneJsonObjectMapper.class, resolved.getObjectMapper());
+    }
+
+    @Test
     void twoIndependentLeavesThrowNamingBothModels() throws IOException {
         Path firstContainer = Files.createDirectories(tempDir.resolve("first"));
         Path secondContainer = Files.createDirectories(tempDir.resolve("second"));
@@ -496,7 +527,7 @@ class DefaultModelSerialisationTest {
     }
 
     private void writeAncestryMarker(Path container, boolean configPresent, String runeMavenPluginVersion,
-            String modelSourceGav, String modelId, String ancestorModels) throws IOException {
+            String modelSourceGav, String modelId, String parentModels) throws IOException {
         Path marker = container.resolve(MARKER_RELATIVE_PATH);
         Files.createDirectories(marker.getParent());
         Properties properties = new Properties();
@@ -510,8 +541,8 @@ class DefaultModelSerialisationTest {
         if (modelId != null) {
             properties.setProperty("modelId", modelId);
         }
-        if (ancestorModels != null) {
-            properties.setProperty("ancestorModels", ancestorModels);
+        if (parentModels != null) {
+            properties.setProperty("parentModels", parentModels);
         }
         try (OutputStream out = Files.newOutputStream(marker)) {
             properties.store(out, null);

--- a/src/test/java/com/regnosys/testing/serialisation/DefaultModelSerialisationTest.java
+++ b/src/test/java/com/regnosys/testing/serialisation/DefaultModelSerialisationTest.java
@@ -34,6 +34,7 @@ import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
 
@@ -502,7 +503,58 @@ class DefaultModelSerialisationTest {
         assertInstanceOf(RuneJsonObjectMapper.class, resolved.getObjectMapper());
     }
 
+    @Test
+    void markerEnumerationFailureThrowsInsteadOfFallingBackToClasspathOrder() throws IOException {
+        // A readable marker declaring RUNE_JSON is reachable via the single-resource lookup, so a
+        // fallback to classpath order would resolve off it and silently adopt its format. An unreadable
+        // classpath must fail loudly instead: degrading here reinstates the very classpath-order
+        // semantics the marker replaces, in the place it is hardest to spot.
+        Files.writeString(tempDir.resolve("rune-config.yml"), """
+                model:
+                  name: Test Model
+                  defaultSerialisationFormat: RUNE_JSON
+                """, StandardCharsets.UTF_8);
+        writeAncestryMarker(tempDir, true, DEFAULT_VERSION,
+                "org.example:test-model-java:1.0.0", "org.example:test-model-parent", "");
+        ClassLoader classLoader = new EnumerationFailingClassLoader(dirClassLoader());
+        assertNotNull(classLoader.getResource(MARKER_RELATIVE_PATH), "fallback lookup must be able to succeed");
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> DefaultModelSerialisation.resolve(classLoader));
+
+        assertTrue(exception.getMessage().contains(MARKER_RELATIVE_PATH));
+        assertInstanceOf(IOException.class, exception.getCause());
+    }
+
     // ---- fixtures ----
+
+    /**
+     * A classloader whose marker <em>enumeration</em> fails while its single-resource lookup still
+     * succeeds — the one shape in which a fallback to {@link ClassLoader#getResource(String)} would have
+     * resolved a marker rather than surfacing the IO failure.
+     */
+    private static final class EnumerationFailingClassLoader extends ClassLoader {
+
+        private final ClassLoader delegate;
+
+        private EnumerationFailingClassLoader(ClassLoader delegate) {
+            super(null);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (MARKER_RELATIVE_PATH.equals(name)) {
+                throw new IOException("simulated unreadable classpath entry");
+            }
+            return delegate.getResources(name);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            return delegate.getResource(name);
+        }
+    }
 
     private ClassLoader configClassLoader(String fileName, String yaml) throws IOException {
         Files.writeString(tempDir.resolve(fileName), yaml, StandardCharsets.UTF_8);

--- a/src/test/java/com/regnosys/testing/serialisation/DefaultModelSerialisationTest.java
+++ b/src/test/java/com/regnosys/testing/serialisation/DefaultModelSerialisationTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -34,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -43,6 +45,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DefaultModelSerialisationTest {
+
+    private static final String MARKER_RELATIVE_PATH = "META-INF/rune/model.properties";
+    private static final String DEFAULT_VERSION = "10.4.0";
 
     @TempDir
     Path tempDir;
@@ -74,7 +79,8 @@ class DefaultModelSerialisationTest {
     }
 
     @Test
-    void noConfigOnClasspathResolvesToLegacyMapper() throws MalformedURLException {
+    void noConfigOnClasspathResolvesToLegacyMapper() throws IOException {
+        writeMarker(tempDir, false, DEFAULT_VERSION);
         ClassLoader classLoader = dirClassLoader();
 
         DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(classLoader);
@@ -137,6 +143,7 @@ class DefaultModelSerialisationTest {
                   name: Test Model
                   defaultSerialisationFormat: JSON
                 """, StandardCharsets.UTF_8);
+        writeMarker(tempDir, true, DEFAULT_VERSION);
 
         DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(dirClassLoader());
 
@@ -227,12 +234,127 @@ class DefaultModelSerialisationTest {
         assertTrue(exception.getMessage().contains("XML"));
     }
 
+    @Test
+    void markerAbsentThrowsNamingBothArtifacts() throws MalformedURLException {
+        ClassLoader classLoader = dirClassLoader();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> DefaultModelSerialisation.resolve(classLoader));
+
+        assertTrue(exception.getMessage().contains("rune-maven-plugin"));
+        assertTrue(exception.getMessage().contains("rune-testing"));
+    }
+
+    @Test
+    void markerFalseIgnoresPresentConfigOnClasspath() throws IOException {
+        Files.writeString(tempDir.resolve("rune-config.yml"), """
+                model:
+                  name: Test Model
+                  defaultSerialisationFormat: RUNE_JSON
+                """, StandardCharsets.UTF_8);
+        writeMarker(tempDir, false, DEFAULT_VERSION);
+
+        DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(dirClassLoader());
+
+        assertFalse(resolved.getObjectMapper() instanceof RuneJsonObjectMapper);
+    }
+
+    @Test
+    void markerTrueResolvesConfigFromItsOwnContainerAmongTwoContainers() throws IOException {
+        Path dependencyContainer = Files.createDirectories(tempDir.resolve("dependency"));
+        Path modelContainer = Files.createDirectories(tempDir.resolve("model"));
+
+        // A dependency on the classpath ships its own (differently-formatted, marker-less) config.
+        Files.writeString(dependencyContainer.resolve("rune-config.yml"), """
+                model:
+                  name: Dependency Model
+                  defaultSerialisationFormat: JSON
+                """, StandardCharsets.UTF_8);
+
+        // This model ships its own marker and its own config, in its own container.
+        Files.writeString(modelContainer.resolve("rune-config.yml"), """
+                model:
+                  name: Test Model
+                  defaultSerialisationFormat: RUNE_JSON
+                """, StandardCharsets.UTF_8);
+        writeMarker(modelContainer, true, DEFAULT_VERSION);
+
+        // The dependency's container comes first in classpath order, adversarially.
+        ClassLoader classLoader = containersClassLoader(dependencyContainer, modelContainer);
+
+        DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(classLoader);
+
+        assertInstanceOf(RuneJsonObjectMapper.class, resolved.getObjectMapper());
+    }
+
+    @Test
+    void ancestorMarkerWithHigherPluginVersionThrows() throws IOException {
+        Path childContainer = Files.createDirectories(tempDir.resolve("child"));
+        Path ancestorContainer = Files.createDirectories(tempDir.resolve("ancestor"));
+        writeMarker(childContainer, false, "10.3.0");
+        writeMarker(ancestorContainer, false, "10.4.0");
+
+        ClassLoader classLoader = containersClassLoader(childContainer, ancestorContainer);
+
+        assertThrows(IllegalStateException.class, () -> DefaultModelSerialisation.resolve(classLoader));
+    }
+
+    @Test
+    void conventionCheckSkippedWhenWinningMarkerHasNoVersion() throws IOException {
+        Path childContainer = Files.createDirectories(tempDir.resolve("child"));
+        Path ancestorContainer = Files.createDirectories(tempDir.resolve("ancestor"));
+        writeMarker(childContainer, false, null);
+        writeMarker(ancestorContainer, false, "999.0.0");
+
+        ClassLoader classLoader = containersClassLoader(childContainer, ancestorContainer);
+
+        DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(classLoader);
+
+        assertFalse(resolved.getObjectMapper() instanceof RuneJsonObjectMapper);
+    }
+
+    @Test
+    void conventionCheckSkippedWhenAnAncestorMarkerHasNoVersion() throws IOException {
+        Path childContainer = Files.createDirectories(tempDir.resolve("child"));
+        Path ancestorContainer = Files.createDirectories(tempDir.resolve("ancestor"));
+        writeMarker(childContainer, false, "10.3.0");
+        writeMarker(ancestorContainer, false, null);
+
+        ClassLoader classLoader = containersClassLoader(childContainer, ancestorContainer);
+
+        DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(classLoader);
+
+        assertFalse(resolved.getObjectMapper() instanceof RuneJsonObjectMapper);
+    }
+
     private ClassLoader configClassLoader(String fileName, String yaml) throws IOException {
         Files.writeString(tempDir.resolve(fileName), yaml, StandardCharsets.UTF_8);
+        writeMarker(tempDir, true, DEFAULT_VERSION);
         return dirClassLoader();
     }
 
     private ClassLoader dirClassLoader() throws MalformedURLException {
         return new URLClassLoader(new URL[]{tempDir.toUri().toURL()}, null);
+    }
+
+    private ClassLoader containersClassLoader(Path... containers) throws MalformedURLException {
+        URL[] urls = new URL[containers.length];
+        for (int i = 0; i < containers.length; i++) {
+            urls[i] = containers[i].toUri().toURL();
+        }
+        return new URLClassLoader(urls, null);
+    }
+
+    private void writeMarker(Path container, boolean configPresent, String runeMavenPluginVersion) throws IOException {
+        Path marker = container.resolve(MARKER_RELATIVE_PATH);
+        Files.createDirectories(marker.getParent());
+        Properties properties = new Properties();
+        properties.setProperty("runeConfigPresentInModel", String.valueOf(configPresent));
+        if (runeMavenPluginVersion != null) {
+            properties.setProperty("runeMavenPluginVersion", runeMavenPluginVersion);
+        }
+        try (OutputStream out = Files.newOutputStream(marker)) {
+            properties.store(out, null);
+        }
     }
 }

--- a/src/test/java/com/regnosys/testing/serialisation/DefaultModelSerialisationTest.java
+++ b/src/test/java/com/regnosys/testing/serialisation/DefaultModelSerialisationTest.java
@@ -211,7 +211,9 @@ class DefaultModelSerialisationTest {
     }
 
     public static class UnsortedBean {
+        @SuppressWarnings("unused")
         public String zulu = "z";
+        @SuppressWarnings("unused")
         public String alpha = "a";
     }
 

--- a/src/test/java/com/regnosys/testing/serialisation/DefaultModelSerialisationTest.java
+++ b/src/test/java/com/regnosys/testing/serialisation/DefaultModelSerialisationTest.java
@@ -327,9 +327,154 @@ class DefaultModelSerialisationTest {
         assertFalse(resolved.getObjectMapper() instanceof RuneJsonObjectMapper);
     }
 
+    // ---- leaf election ----
+
+    @Test
+    void leafWinsEvenWhenItsAncestorsMarkerComesFirstOnTheClasspath() throws IOException {
+        // The sortpom scenario v1 could not survive: the ancestor's jar is listed before the
+        // child's, so its marker enumerates first, yet ancestry still elects the child.
+        Path ancestorContainer = Files.createDirectories(tempDir.resolve("ancestor"));
+        Path childContainer = Files.createDirectories(tempDir.resolve("child"));
+        Files.writeString(ancestorContainer.resolve("rune-config.yml"), """
+                model:
+                  name: Ancestor Model
+                  defaultSerialisationFormat: JSON
+                """, StandardCharsets.UTF_8);
+        writeAncestryMarker(ancestorContainer, true, DEFAULT_VERSION,
+                "org.example:ancestor-java:1.0.0", "org.example:ancestor-parent", "");
+        Files.writeString(childContainer.resolve("rune-config.yml"), """
+                model:
+                  name: Child Model
+                  defaultSerialisationFormat: RUNE_JSON
+                """, StandardCharsets.UTF_8);
+        writeAncestryMarker(childContainer, true, DEFAULT_VERSION,
+                "org.example:child-java:2.0.0", "org.example:child-parent", "org.example:ancestor-parent");
+
+        DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(
+                containersClassLoader(ancestorContainer, childContainer));
+
+        assertInstanceOf(RuneJsonObjectMapper.class, resolved.getObjectMapper());
+    }
+
+    @Test
+    void twoIndependentLeavesThrowNamingBothModels() throws IOException {
+        Path firstContainer = Files.createDirectories(tempDir.resolve("first"));
+        Path secondContainer = Files.createDirectories(tempDir.resolve("second"));
+        writeAncestryMarker(firstContainer, false, DEFAULT_VERSION,
+                "org.example:first-java:1.0.0", "org.example:first-parent", "");
+        writeAncestryMarker(secondContainer, false, DEFAULT_VERSION,
+                "org.example:second-java:1.0.0", "org.example:second-parent", "");
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> DefaultModelSerialisation.resolve(containersClassLoader(firstContainer, secondContainer)));
+
+        assertTrue(exception.getMessage().contains("org.example:first-java:1.0.0"));
+        assertTrue(exception.getMessage().contains("org.example:second-java:1.0.0"));
+    }
+
+    @Test
+    void anyPreAncestryMarkerDisablesElectionAndFallsBackToClasspathOrder() throws IOException {
+        // The first marker is a v1 one (no modelId); by ancestry the second would win, but the
+        // compatibility gate keeps classpath order, so the v1 marker's answer (no config) sticks.
+        Path v1Container = Files.createDirectories(tempDir.resolve("v1"));
+        Path childContainer = Files.createDirectories(tempDir.resolve("child"));
+        writeMarker(v1Container, false, DEFAULT_VERSION);
+        Files.writeString(childContainer.resolve("rune-config.yml"), """
+                model:
+                  name: Child Model
+                  defaultSerialisationFormat: RUNE_JSON
+                """, StandardCharsets.UTF_8);
+        writeAncestryMarker(childContainer, true, DEFAULT_VERSION,
+                "org.example:child-java:2.0.0", "org.example:child-parent", "");
+
+        DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(
+                containersClassLoader(v1Container, childContainer));
+
+        assertFalse(resolved.getObjectMapper() instanceof RuneJsonObjectMapper);
+    }
+
+    @Test
+    void ancestryCycleFallsBackToClasspathOrder() throws IOException {
+        // Zero leaves - only possible with corrupted markers; must not block the build.
+        Path firstContainer = Files.createDirectories(tempDir.resolve("first"));
+        Path secondContainer = Files.createDirectories(tempDir.resolve("second"));
+        Files.writeString(firstContainer.resolve("rune-config.yml"), """
+                model:
+                  name: First Model
+                  defaultSerialisationFormat: RUNE_JSON
+                """, StandardCharsets.UTF_8);
+        writeAncestryMarker(firstContainer, true, DEFAULT_VERSION,
+                "org.example:first-java:1.0.0", "org.example:first-parent", "org.example:second-parent");
+        writeAncestryMarker(secondContainer, false, DEFAULT_VERSION,
+                "org.example:second-java:1.0.0", "org.example:second-parent", "org.example:first-parent");
+
+        DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(
+                containersClassLoader(firstContainer, secondContainer));
+
+        assertInstanceOf(RuneJsonObjectMapper.class, resolved.getObjectMapper());
+    }
+
+    @Test
+    void singleRootModelMarkerWinsTrivially() throws IOException {
+        Files.writeString(tempDir.resolve("rune-config.yml"), """
+                model:
+                  name: Root Model
+                  defaultSerialisationFormat: RUNE_JSON
+                """, StandardCharsets.UTF_8);
+        writeAncestryMarker(tempDir, true, DEFAULT_VERSION,
+                "com.regnosys.rune-fpml:rosetta-source:1.2.3", "com.regnosys.rune-fpml:parent", "");
+
+        DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(dirClassLoader());
+
+        assertInstanceOf(RuneJsonObjectMapper.class, resolved.getObjectMapper());
+    }
+
+    @Test
+    void versionConventionCheckStillFiresUnderLeafElection() throws IOException {
+        // The elected leaf (the child) has an older plugin version than its ancestor - orthogonal
+        // to election, this must still throw, naming the models rather than URLs.
+        Path ancestorContainer = Files.createDirectories(tempDir.resolve("ancestor"));
+        Path childContainer = Files.createDirectories(tempDir.resolve("child"));
+        writeAncestryMarker(ancestorContainer, false, "10.4.0",
+                "org.example:ancestor-java:1.0.0", "org.example:ancestor-parent", "");
+        writeAncestryMarker(childContainer, false, "10.3.0",
+                "org.example:child-java:2.0.0", "org.example:child-parent", "org.example:ancestor-parent");
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> DefaultModelSerialisation.resolve(containersClassLoader(ancestorContainer, childContainer)));
+
+        assertTrue(exception.getMessage().contains("org.example:ancestor-java:1.0.0"));
+        assertTrue(exception.getMessage().contains("org.example:child-java:2.0.0"));
+    }
+
+    @Test
+    void duplicateMarkersOfTheSameModelAreOneLeafNotAnAmbiguity() throws IOException {
+        // The same model appearing twice on the classpath is not two independent model graphs;
+        // classpath order breaks the tie.
+        Path firstContainer = Files.createDirectories(tempDir.resolve("first"));
+        Path secondContainer = Files.createDirectories(tempDir.resolve("second"));
+        Files.writeString(firstContainer.resolve("rune-config.yml"), """
+                model:
+                  name: Test Model
+                  defaultSerialisationFormat: RUNE_JSON
+                """, StandardCharsets.UTF_8);
+        writeAncestryMarker(firstContainer, true, DEFAULT_VERSION,
+                "org.example:model-java:1.0.0", "org.example:model-parent", "");
+        writeAncestryMarker(secondContainer, false, DEFAULT_VERSION,
+                "org.example:model-java:1.0.0", "org.example:model-parent", "");
+
+        DefaultModelSerialisation resolved = DefaultModelSerialisation.resolve(
+                containersClassLoader(firstContainer, secondContainer));
+
+        assertInstanceOf(RuneJsonObjectMapper.class, resolved.getObjectMapper());
+    }
+
+    // ---- fixtures ----
+
     private ClassLoader configClassLoader(String fileName, String yaml) throws IOException {
         Files.writeString(tempDir.resolve(fileName), yaml, StandardCharsets.UTF_8);
-        writeMarker(tempDir, true, DEFAULT_VERSION);
+        writeAncestryMarker(tempDir, true, DEFAULT_VERSION,
+                "org.example:test-model-java:1.0.0", "org.example:test-model-parent", "");
         return dirClassLoader();
     }
 
@@ -345,13 +490,28 @@ class DefaultModelSerialisationTest {
         return new URLClassLoader(urls, null);
     }
 
+    /** A v1 marker, as written by a pre-ancestry rune-maven-plugin: no identity/ancestry keys. */
     private void writeMarker(Path container, boolean configPresent, String runeMavenPluginVersion) throws IOException {
+        writeAncestryMarker(container, configPresent, runeMavenPluginVersion, null, null, null);
+    }
+
+    private void writeAncestryMarker(Path container, boolean configPresent, String runeMavenPluginVersion,
+            String modelSourceGav, String modelId, String ancestorModels) throws IOException {
         Path marker = container.resolve(MARKER_RELATIVE_PATH);
         Files.createDirectories(marker.getParent());
         Properties properties = new Properties();
         properties.setProperty("runeConfigPresentInModel", String.valueOf(configPresent));
         if (runeMavenPluginVersion != null) {
             properties.setProperty("runeMavenPluginVersion", runeMavenPluginVersion);
+        }
+        if (modelSourceGav != null) {
+            properties.setProperty("modelSourceGav", modelSourceGav);
+        }
+        if (modelId != null) {
+            properties.setProperty("modelId", modelId);
+        }
+        if (ancestorModels != null) {
+            properties.setProperty("ancestorModels", ancestorModels);
         }
         try (OutputStream out = Files.newOutputStream(marker)) {
             properties.store(out, null);

--- a/src/test/resources/META-INF/rune/model.properties
+++ b/src/test/resources/META-INF/rune/model.properties
@@ -3,3 +3,6 @@
 #PipelineTestPackWriterDefaultSerialisationTest).
 runeConfigPresentInModel=false
 runeMavenPluginVersion=10.3.0
+modelSourceGav=org.finos.rune-testing:rune-testing:0.0.0.main-SNAPSHOT
+modelId=org.finos.rune-testing:rune-testing
+ancestorModels=

--- a/src/test/resources/META-INF/rune/model.properties
+++ b/src/test/resources/META-INF/rune/model.properties
@@ -1,0 +1,5 @@
+#This module has no rune-config.yml/rosetta-config.yml of its own; fixture marker for tests that resolve
+#DefaultModelSerialisation off this module's own real test classpath (see TransformTestExtensionDefaultSerialisationTest,
+#PipelineTestPackWriterDefaultSerialisationTest).
+runeConfigPresentInModel=false
+runeMavenPluginVersion=10.3.0

--- a/src/test/resources/META-INF/rune/model.properties
+++ b/src/test/resources/META-INF/rune/model.properties
@@ -5,4 +5,4 @@ runeConfigPresentInModel=false
 runeMavenPluginVersion=10.3.0
 modelSourceGav=org.finos.rune-testing:rune-testing:0.0.0.main-SNAPSHOT
 modelId=org.finos.rune-testing:rune-testing
-ancestorModels=
+parentModels=


### PR DESCRIPTION
## Problem

`DefaultModelSerialisation.resolve()` locates a model's `rune-config.yml`/`rosetta-config.yml` via
`ClassLoader#getResource`, which returns the first match in classpath order. A child model that ships
no config of its own can silently pick up an ancestor's config file and adopt its
`defaultSerialisationFormat` — so a child never opts into `RUNE_JSON` but still gets treated as if it
did. And even once a marker records whether *a given* model has its own config, a consumer classpath
that lists an ancestor model jar before its own (e.g. alphabetical dependency sorting) can still make
the wrong marker win when several models are present at once.

## Fix

Replace classpath-order inference with an explicit, per-model marker, and elect the winning marker by
the model graph rather than by which one happens to come first. A companion change to
`rune-maven-plugin` (in `rune-dsl`) now writes `META-INF/rune/model.properties` into every model's
build output, recording:

- whether *that model* ships its own config (`runeConfigPresentInModel`),
- the plugin version that produced the marker (`runeMavenPluginVersion`),
- the model's own repo identity (`modelId`) and its *direct* model parents (`parentModels`).

`rune-testing` now consults these markers instead of guessing:

- **No marker on the classpath** → throw. The message names both `rune-maven-plugin` and
  `rune-testing` since they ship as a pair, and this is the failure mode of a new `rune-testing`
  against an old plugin.
- **Markers cannot be enumerated or read at all** → throw. An `IOException` from `getResources` means
  the classpath itself is unreadable (a corrupt or unreadable jar or classes directory), not that a
  marker is malformed, so it fails with that diagnosis rather than degrading to a single
  `getResource` lookup — degrading there would reinstate exactly the classpath-order semantics this
  change replaces, and could silently elect an ancestor's marker in the place it is hardest to spot.
  Matches the existing policy for an unreadable individual marker. The classpath-order fallback is
  therefore reached only from leaf election, for the two deliberate cases below.
- **Several markers present** → elect the **leaf**: the marker whose `modelId` appears in no other
  marker's `parentModels`, independent of classpath order. Every non-root model on a test classpath
  carries a marker contributing its own parent edge (an ancestor is ruled out by its *child's* marker,
  not by the model under test declaring the whole chain), so direct parents are enough to identify the
  leaf without needing a transitive closure.
  - Exactly one leaf → wins, regardless of where it sits on the classpath (the sortpom/mis-ordered-pom
    scenario this whole change exists for).
  - Several markers agreeing on one `modelId` (the same model twice on the classpath) → one leaf, not
    an ambiguity.
  - Multiple *different* leaves → throws, naming each leaf by its `modelSourceGav` and both possible
    causes: two unrelated model graphs on one classpath, or an intermediate model jar with no marker.
  - No leaf (an ancestry cycle, only reachable via corrupted markers) → falls back to classpath order
    with a warning rather than blocking the build.
  - Any marker missing `modelId` (a pre-ancestry marker) → election is skipped entirely and the first
    marker in classpath order wins, so models built with the older plugin keep working.
  - The resolution decision is logged at info, naming the winning `modelSourceGav`/`modelId`, so a
    mis-ordered pom is now observable even while election is in fallback mode.
- **`runeConfigPresentInModel=false`** on the winning marker → legacy `RosettaObjectMapper`, with no
  config lookup at all. This is the actual bug fix — a model with no config of its own can no longer
  inherit a dependency's.
- **`=true`** → the config is resolved *relative to the winning marker's own container* (strip
  `META-INF/rune/model.properties` off the marker's URL, then look for
  `rune-config.yml`/`rosetta-config.yml` alongside it), never via a second classpath-order lookup.
  Handles both `jar:file:/…!/` and exploded `file:/…/target/classes/` URL forms.
- **`=true` but no config found in that container** → throw (broken build, not an opt-out).

**Convention check:** independent of leaf election, still enumerates every marker on the classpath and
fails if any *other* marker declares a `runeMavenPluginVersion` newer than the winning one — that would
mean an ancestor was built with a newer plugin than the model under test, violating the team convention
that a child's dsl/bundle version is always ≥ its parent's. Versions are compared with
`org.apache.maven.artifact.versioning.ComparableVersion`; an absent/unparseable version on either side
skips the check rather than failing the build.

## Other changes

- Added `maven-artifact` as an explicit dependency in `pom.xml` (pinned to `3.9.14`, matching the
  version already pulled in transitively via `rune-common` → `rune-maven-plugin` →
  `maven-plugin-api`), since `DefaultModelSerialisation` now uses `ComparableVersion` at compile time.
- Fixed deprecated `MapperFeature.SORT_PROPERTIES_ALPHABETICALLY` usage in `createWriter` — now applied
  via `ObjectMapper#setConfig` on the serialization/deserialization configs rather than the deprecated
  mutating `configure` call.
- Added a `src/test/resources/META-INF/rune/model.properties` fixture (`runeConfigPresentInModel=false`)
  so tests that resolve `DefaultModelSerialisation` off this module's own real test classpath
  (`TransformTestExtensionDefaultSerialisationTest`, `PipelineTestPackWriterDefaultSerialisationTest`)
  keep passing now that a marker is mandatory.

## Tests

28 cases in `DefaultModelSerialisationTest`, including:
- marker absent → throws, message names both artifacts
- marker enumeration failing while the single-resource lookup still succeeds, over a *readable* marker
  declaring `RUNE_JSON` → throws rather than resolving off it (asserts as a precondition that the
  fallback lookup would have succeeded, so it pins the silent-wrong-answer case, not just the throw)
- marker `false` with a config present on the classpath → legacy mapper (direct regression test for
  the original bug)
- marker `true` with configs in two containers → resolves the marker's own container, not the
  classpath-first one
- an ancestor marker declaring a higher `runeMavenPluginVersion` → throws; winning/ancestor marker
  missing a version → check skipped either way
- leaf wins even when its ancestor's marker comes first on the classpath (the sortpom regression)
- a three-model chain: the grandparent is ruled out by the *intermediate's* marker, not the leaf's —
  the property that makes direct parents sufficient without a transitive closure
- two independent leaves → throws, naming both models
- any pre-ancestry marker present → classpath-order fallback, no throw
- an ancestry cycle (synthetic) → classpath-order fallback with a warning
- a single root-model marker (empty `parentModels`) → wins trivially
- duplicate markers of the same model → one leaf, not an ambiguity
- the plugin-version convention check still fires under leaf election (orthogonality)

## Companion change

This must ship together with the corresponding `rune-maven-plugin` change in `rune-dsl` (marker
emission, including the model identity/ancestry keys) — `rune-testing` hard-fails without a marker at
all, and needs the identity/ancestry keys present to elect a leaf rather than fall back to classpath
order.

