### PR TITLE
[11.x.x] - fix: normalise line endings when reading expectation files

### DIFF
--- a/src/main/java/com/regnosys/testing/TestingExpectationUtil.java
+++ b/src/main/java/com/regnosys/testing/TestingExpectationUtil.java
@@ -21,6 +21,7 @@ package com.regnosys.testing;
  */
 
 import com.regnosys.rosetta.common.util.ClassPathUtils;
+import com.regnosys.rosetta.common.util.LineEndings;
 import com.regnosys.rosetta.common.util.UrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,10 +44,19 @@ public class TestingExpectationUtil {
     public static Optional<Path> TEST_WRITE_BASE_PATH = Optional.ofNullable(System.getenv("TEST_WRITE_BASE_PATH"))
             .map(Paths::get);
 
+    /**
+     * Reads an expectation file from the classpath, normalised to "\n".
+     * <p>
+     * Expectation files are compared against output that is always produced with
+     * "\n". A repository without a {@code .gitattributes} checks them out with CRLF
+     * on Windows, so without normalising here the comparison would depend on which
+     * operating system the file was checked out on.
+     */
     public static String readStringFromResources(Path resourcePath) {
         return Optional.ofNullable(ClassPathUtils.getResource(resourcePath))
                 .map(UrlUtils::toPath)
                 .map(TestingExpectationUtil::readString)
+                .map(LineEndings::normalise)
                 .orElse(null);
     }
 
@@ -61,14 +71,17 @@ public class TestingExpectationUtil {
 
     public static void assertJsonEquals(String expectedJson, String resultJson) {
         assertEquals(
-                normaliseLineEndings(expectedJson),
-                normaliseLineEndings(resultJson));
+                LineEndings.normalise(expectedJson),
+                LineEndings.normalise(resultJson));
     }
 
+    /**
+     * @deprecated use {@link LineEndings#normalise(String)}, which is reachable from
+     *             repositories that do not depend on rune-testing.
+     */
+    @Deprecated
     public static String normaliseLineEndings(String str) {
-        return Optional.ofNullable(str)
-                .map(s -> s.replace("\r", ""))
-                .orElse(null);
+        return LineEndings.normalise(str);
     }
 
     public static void writeFile(Path writePath, String json, boolean create) {

--- a/src/main/java/com/regnosys/testing/schemeimport/SchemeImporterTestHelper.java
+++ b/src/main/java/com/regnosys/testing/schemeimport/SchemeImporterTestHelper.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.regnosys.rosetta.common.serialisation.reportdata.ReportDataItem;
 import com.regnosys.rosetta.common.util.ClassPathUtils;
 import com.regnosys.rosetta.common.util.CollectionUtils;
+import com.regnosys.rosetta.common.util.LineEndings;
 import com.regnosys.rosetta.common.util.UrlUtils;
 import com.regnosys.rosetta.rosetta.RosettaEnumValue;
 import com.regnosys.rosetta.rosetta.RosettaEnumeration;
@@ -135,7 +136,11 @@ public class SchemeImporterTestHelper {
         URL rosettaPath = Arrays.stream(rosettaPaths)
                 .filter(x -> getFileName(x.getFile()).equals(fileName))
                 .findFirst().orElseThrow();
-        String contents = new String(rosettaPath.openStream().readAllBytes(), StandardCharsets.UTF_8);
+        // Normalised to "\n": the committed .rosetta file is compared against generated
+        // content, which is always produced with "\n", but checks out with CRLF on
+        // Windows in a repository without a .gitattributes
+        String contents = LineEndings.normalise(
+                new String(rosettaPath.openStream().readAllBytes(), StandardCharsets.UTF_8));
         return RosettaResourceWriter.rewriteProjectVersion(contents);
     }
 

--- a/src/main/java/com/regnosys/testing/transform/TransformTestExtension.java
+++ b/src/main/java/com/regnosys/testing/transform/TransformTestExtension.java
@@ -31,6 +31,7 @@ import com.google.inject.Module;
 import com.regnosys.rosetta.common.serialisation.RosettaObjectMapper;
 import com.regnosys.rosetta.common.transform.PipelineModel;
 import com.regnosys.rosetta.common.transform.TestPackModel;
+import com.regnosys.rosetta.common.util.LineEndings;
 import com.regnosys.rosetta.common.transform.TestPackUtils;
 import com.regnosys.rosetta.common.util.UrlUtils;
 import com.regnosys.testing.TestingExpectationUtil;
@@ -63,7 +64,6 @@ import java.util.stream.Stream;
 import static com.regnosys.rosetta.common.transform.TestPackUtils.*;
 import static com.regnosys.rosetta.common.transform.TestPackUtils.getPipelineModel;
 import static com.regnosys.testing.TestingExpectationUtil.readStringFromResources;
-import static com.regnosys.testing.TestingExpectationUtil.normaliseLineEndings;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -198,7 +198,7 @@ public class TransformTestExtension<T> implements BeforeAllCallback, AfterAllCal
         }
 
         String expectedOutput = readStringFromResources(Path.of(sampleModel.getOutputPath()));
-        assertEquals(normaliseLineEndings(expectedOutput), normaliseLineEndings(actualOutput));
+        assertEquals(LineEndings.normalise(expectedOutput), LineEndings.normalise(actualOutput));
 
         TestPackModel.SampleModel.Assertions expectedAssertions = sampleModel.getAssertions();
         assertEquals(expectedAssertions, actualAssertions);

--- a/src/test/java/com/regnosys/testing/TestingExpectationUtilTest.java
+++ b/src/test/java/com/regnosys/testing/TestingExpectationUtilTest.java
@@ -1,0 +1,71 @@
+package com.regnosys.testing;
+
+/*-
+ * ===============
+ * Rune Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class TestingExpectationUtilTest {
+
+    private static final String LF_EXPECTATION = "{\n  \"a\" : 1\n}";
+    private static final String CRLF_EXPECTATION = "{\r\n  \"a\" : 1\r\n}";
+
+    /**
+     * An expectation file checked out on Windows (CRLF) has to compare equal to the
+     * same file checked out on Linux (LF), because the output it is compared against
+     * is always produced with "\n".
+     */
+    @Test
+    void expectationReadFromResourcesIsNormalisedToLf() throws Exception {
+        Path crlfResource = writeToTargetTestClasses("crlf-expectation.json", CRLF_EXPECTATION);
+        try {
+            String read = TestingExpectationUtil.readStringFromResources(Path.of("crlf-expectation.json"));
+            assertEquals(LF_EXPECTATION, read);
+        } finally {
+            Files.deleteIfExists(crlfResource);
+        }
+    }
+
+    @Test
+    void missingResourceStillReadsAsNull() {
+        assertNull(TestingExpectationUtil.readStringFromResources(Path.of("does-not-exist.json")));
+    }
+
+    @Test
+    void assertJsonEqualsAcceptsEitherLineEnding() {
+        TestingExpectationUtil.assertJsonEquals(CRLF_EXPECTATION, LF_EXPECTATION);
+        TestingExpectationUtil.assertJsonEquals(LF_EXPECTATION, CRLF_EXPECTATION);
+    }
+
+    private static Path writeToTargetTestClasses(String fileName, String content) throws Exception {
+        Path classesDir = Path.of(
+                TestingExpectationUtilTest.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        Path file = classesDir.resolve(fileName);
+        Files.write(file, content.getBytes(StandardCharsets.UTF_8));
+        return file;
+    }
+}


### PR DESCRIPTION
Backport of #368 to the `11.x.x` line. Cherry-picked with `-x`, applied cleanly, no changes from `main`.

**Depends on the rune-common `11.x.x` backport** — CI here stays red until that merges and republishes `0.0.0.11.x.x-SNAPSHOT`, because `LineEndings` lives there.

## Why

The Windows-compatibility work pinned serialiser pretty printing to `"\n"` where it previously followed `System.lineSeparator()`. On Windows an expectation file checks out CRLF (no `.gitattributes`, `core.autocrlf=true`): it matched the old CRLF output and no longer matches the new LF output. Reproduced in the CDM. The 11.x line carries the same defect, released in bundle 11.125.0.

## This change

Normalises at the point an expectation is **read**, so a CRLF checkout behaves like an LF one and consumers inherit the tolerance without touching their assertions:

- `TestingExpectationUtil.readStringFromResources` normalises what it reads
- `SchemeImporterTestHelper.getContents` does the same — it reads a committed `.rosetta` file that subclasses compare against generated content
- `normaliseLineEndings` delegates to `LineEndings.normalise` and is deprecated; `assertJsonEquals` and `TransformTestExtension` call the shared helper directly

`readString(Path)` is deliberately left raw — general-purpose file read, not an expectation read.

## Tests

`TestingExpectationUtilTest`, the key case asserting a CRLF expectation on the classpath reads back as LF. Confirmed non-vacuous on `main` by removing the normalisation and watching it fail. Verified locally on this branch against the backported rune-common: **79 tests, 0 failures**.

## Behaviour change to note

`normaliseLineEndings` previously stripped `\r` outright, joining lines for lone-CR content; `LineEndings.normalise` converts it to a newline. They differ only for lone-CR input, which no JSON/XML expectation file realistically contains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)