### PR TITLE
Restrict Slack notifications to scheduled runs only in CVE scanning workflow, notify on success too

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
   schedule:
     # Run daily to catch newly published CVEs even without repo changes.
-    - cron: '0 3 * * *'
+    # Staggered across repos (rune-dsl 01:00, rune-common 01:30, rune-testing
+    # 02:00) to avoid all three hitting the NVD API / shared runners at once.
+    - cron: '0 2 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -106,14 +106,27 @@ jobs:
             echo "::warning::The scan step still succeeded, using the last previously cached NVD data - it may be a few days stale until an update fully completes."
           fi
       # Notify Slack if the scan itself failed (e.g. a real CVSS>=7 finding),
-      # so the team doesn't have to check the Actions tab.
+      # so the team doesn't have to check the Actions tab. Restricted to the
+      # scheduled cron run so manual/PR/push triggers don't spam the channel.
       - name: Notify Slack on scan failure
-        if: failure() && steps.cve-scanning.outcome == 'failure'
+        if: failure() && steps.cve-scanning.outcome == 'failure' && github.event_name == 'schedule'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_WEBHOOK_URL }}
         run: |
           curl -sf -X POST -H 'Content-type: application/json' \
             --data "{
               \"text\": \":rotating_light: *CVE Scanning* failed for \`${{ github.repository }}\` on \`${{ github.head_ref || github.ref_name }}\` (triggered by \`${{ github.event_name }}\`).\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
+            }" \
+            "$SLACK_WEBHOOK_URL"
+      # Also notify Slack on success for the scheduled run, so the team has
+      # positive confirmation that the daily scan is running and clean.
+      - name: Notify Slack on scan success
+        if: success() && github.event_name == 'schedule'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_WEBHOOK_URL }}
+        run: |
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "{
+              \"text\": \":white_check_mark: *CVE Scanning* passed for \`${{ github.repository }}\` on \`${{ github.head_ref || github.ref_name }}\`.\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
             }" \
             "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
Mirrors REGnosys/rosetta-code-generators#570: manual/PR/push triggers were spamming the Slack channel on CVE scan failure, and there was no positive signal that the daily scheduled scan was running clean.

Please include a summary of the change and the issue/story number.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
