### PR TITLE
Split CVE scanning schedule into its own dispatcher workflow

### DIFF
--- a/.github/workflows/cve-scanning-schedule.yml
+++ b/.github/workflows/cve-scanning-schedule.yml
@@ -12,8 +12,9 @@ on:
     # 02:00) to avoid all three hitting the NVD API / shared runners at once.
     - cron: '0 2 * * *'
 
-permissions:
-  actions: write
+# Neither step below uses the default GITHUB_TOKEN, so it's granted no
+# permissions at all.
+permissions: {}
 
 jobs:
   dispatch:
@@ -23,9 +24,19 @@ jobs:
       matrix:
         ref: [main, 11.x.x]
     steps:
+      # The default GITHUB_TOKEN can't trigger another workflow run (GitHub's
+      # anti-recursion guard silently no-ops workflow_dispatch calls made with
+      # it), so this mints a short-lived token from the shared REGnosys CVE
+      # Scan Dispatcher GitHub App instead.
+      - name: Generate dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CVE_SCAN_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CVE_SCAN_DISPATCH_APP_PRIVATE_KEY }}
       - name: Trigger CVE scanning on ${{ matrix.ref }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh workflow run cve-scanning.yml \
             --ref ${{ matrix.ref }} \

--- a/.github/workflows/cve-scanning-schedule.yml
+++ b/.github/workflows/cve-scanning-schedule.yml
@@ -1,0 +1,33 @@
+name: CVE Scanning Schedule
+
+# Lives only on main. `schedule` always runs the workflow file as it exists on
+# the default branch, so a schedule trigger inside cve-scanning.yml itself
+# could never scan other maintained branches (e.g. 11.x.x) using their own
+# version of that file. Instead this dispatches cve-scanning.yml via
+# workflow_dispatch against each ref, which runs the file as it exists there.
+on:
+  schedule:
+    # Run daily to catch newly published CVEs even without repo changes.
+    # Staggered across repos (rune-dsl 01:00, rune-common 01:30, rune-testing
+    # 02:00) to avoid all three hitting the NVD API / shared runners at once.
+    - cron: '0 2 * * *'
+
+permissions:
+  actions: write
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: [main, 11.x.x]
+    steps:
+      - name: Trigger CVE scanning on ${{ matrix.ref }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run cve-scanning.yml \
+            --ref ${{ matrix.ref }} \
+            --repo ${{ github.repository }} \
+            -f scheduled=true

--- a/.github/workflows/cve-scanning-schedule.yml
+++ b/.github/workflows/cve-scanning-schedule.yml
@@ -12,8 +12,8 @@ on:
     # 02:00) to avoid all three hitting the NVD API / shared runners at once.
     - cron: '0 2 * * *'
 
-# Neither step below uses the default GITHUB_TOKEN, so it's granted no
-# permissions at all.
+# The single step below doesn't use the default GITHUB_TOKEN, so it's
+# granted no permissions at all.
 permissions: {}
 
 jobs:
@@ -26,17 +26,13 @@ jobs:
     steps:
       # The default GITHUB_TOKEN can't trigger another workflow run (GitHub's
       # anti-recursion guard silently no-ops workflow_dispatch calls made with
-      # it), so this mints a short-lived token from the shared REGnosys CVE
-      # Scan Dispatcher GitHub App instead.
-      - name: Generate dispatch token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.CVE_SCAN_DISPATCH_APP_ID }}
-          private-key: ${{ secrets.CVE_SCAN_DISPATCH_APP_PRIVATE_KEY }}
+      # it). This repo is a fork of a FINOS repo, and GitHub App installation
+      # requires org-owner rights we don't have on FINOS, so a fine-grained
+      # PAT (Actions: read/write on this repo only) is stored as a repository
+      # secret here instead of using the shared CVE Scan Dispatcher App.
       - name: Trigger CVE scanning on ${{ matrix.ref }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.CVE_SCAN_DISPATCH_TOKEN }}
         run: |
           gh workflow run cve-scanning.yml \
             --ref ${{ matrix.ref }} \

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -2,11 +2,11 @@ name: CVE Scanning
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run daily to catch newly published CVEs even without repo changes.
-    # Staggered across repos (rune-dsl 01:00, rune-common 01:30, rune-testing
-    # 02:00) to avoid all three hitting the NVD API / shared runners at once.
-    - cron: '0 2 * * *'
+    inputs:
+      scheduled:
+        description: 'Set by cve-scanning-schedule.yml when dispatching this run from the daily cron'
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -108,10 +108,11 @@ jobs:
             echo "::warning::The scan step still succeeded, using the last previously cached NVD data - it may be a few days stale until an update fully completes."
           fi
       # Notify Slack if the scan itself failed (e.g. a real CVSS>=7 finding),
-      # so the team doesn't have to check the Actions tab. Restricted to the
-      # scheduled cron run so manual/PR/push triggers don't spam the channel.
+      # so the team doesn't have to check the Actions tab. Restricted to runs
+      # dispatched by cve-scanning-schedule.yml's daily cron so manual/PR/push
+      # triggers don't spam the channel.
       - name: Notify Slack on scan failure
-        if: failure() && steps.cve-scanning.outcome == 'failure' && github.event_name == 'schedule'
+        if: failure() && steps.cve-scanning.outcome == 'failure' && inputs.scheduled == true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_WEBHOOK_URL }}
         run: |
@@ -123,7 +124,7 @@ jobs:
       # Also notify Slack on success for the scheduled run, so the team has
       # positive confirmation that the daily scan is running and clean.
       - name: Notify Slack on scan success
-        if: success() && github.event_name == 'schedule'
+        if: success() && inputs.scheduled == true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_WEBHOOK_URL }}
         run: |


### PR DESCRIPTION
schedule triggers always run the workflow file as it exists on the default branch, so a schedule block inside cve-scanning.yml could never scan other maintained branches (e.g. 11.x.x) using their own version of that file. cve-scanning-schedule.yml lives only on main, runs on the daily cron, and dispatches cve-scanning.yml via workflow_dispatch against each ref in its matrix so the file runs as it exists there.

Please include a summary of the change and the issue/story number.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
