### PR TITLE
[11.x.x] Move CVE scanning's schedule trigger out of this workflow

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -2,11 +2,11 @@ name: CVE Scanning
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run daily to catch newly published CVEs even without repo changes.
-    # Staggered across repos (rune-dsl 01:00, rune-common 01:30, rune-testing
-    # 02:00) to avoid all three hitting the NVD API / shared runners at once.
-    - cron: '0 2 * * *'
+    inputs:
+      scheduled:
+        description: 'Set by cve-scanning-schedule.yml when dispatching this run from the daily cron'
+        type: boolean
+        default: false
   push:
     branches:
       - 11.x.x
@@ -108,10 +108,11 @@ jobs:
             echo "::warning::The scan step still succeeded, using the last previously cached NVD data - it may be a few days stale until an update fully completes."
           fi
       # Notify Slack if the scan itself failed (e.g. a real CVSS>=7 finding),
-      # so the team doesn't have to check the Actions tab. Restricted to the
-      # scheduled cron run so manual/PR/push triggers don't spam the channel.
+      # so the team doesn't have to check the Actions tab. Restricted to runs
+      # dispatched by cve-scanning-schedule.yml's daily cron so manual/PR/push
+      # triggers don't spam the channel.
       - name: Notify Slack on scan failure
-        if: failure() && steps.cve-scanning.outcome == 'failure' && github.event_name == 'schedule'
+        if: failure() && steps.cve-scanning.outcome == 'failure' && inputs.scheduled == true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_WEBHOOK_URL }}
         run: |
@@ -123,7 +124,7 @@ jobs:
       # Also notify Slack on success for the scheduled run, so the team has
       # positive confirmation that the daily scan is running and clean.
       - name: Notify Slack on scan success
-        if: success() && github.event_name == 'schedule'
+        if: success() && inputs.scheduled == true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_WEBHOOK_URL }}
         run: |


### PR DESCRIPTION
schedule triggers always run using the workflow file on the default branch, so this branch's schedule block never actually fired here. main now dispatches this workflow onto 11.x.x via
cve-scanning-schedule.yml (workflow_dispatch -f scheduled=true).

Please include a summary of the change and the issue/story number.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
