### PR TITLE
Update to DSL 10.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <rune.dsl.version>10.4.0</rune.dsl.version>
+        <rune.dsl.version>10.5.0</rune.dsl.version>
         <rune.common.version>0.0.0.main-SNAPSHOT</rune.common.version>
 
         <xtext.version>2.38.0</xtext.version>


### PR DESCRIPTION
Bump `rune.dsl.version` to 10.5.0 as part of bundle release 12.9.0.