### PR TITLE
Update to DSL 10.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <rune.dsl.version>10.5.0</rune.dsl.version>
+        <rune.dsl.version>10.5.1</rune.dsl.version>
         <rune.common.version>0.0.0.main-SNAPSHOT</rune.common.version>
 
         <xtext.version>2.38.0</xtext.version>


### PR DESCRIPTION
Picks up [rune-dsl 10.5.1](https://github.com/finos/rune-dsl/releases/tag/10.5.1), which fixes the setup's Rune config wiring being dropped by any custom Xtext setup that overrides `createInjector()` ([#1355](https://github.com/finos/rune-dsl/pull/1355)).