### PR TITLE
[11.x.x] Update to DSL 9.88.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <rune.dsl.version>9.88.0</rune.dsl.version>
+        <rune.dsl.version>9.88.1</rune.dsl.version>
         <rosetta.common.version>0.0.0.11.x.x-SNAPSHOT</rosetta.common.version>
 
         <xtext.version>2.38.0</xtext.version>


### PR DESCRIPTION
Picks up [rune-dsl 9.88.1](https://github.com/finos/rune-dsl/releases/tag/9.88.1), the 9.x.x backport of the fix for the setup's Rune config wiring being dropped by any custom Xtext setup that overrides `createInjector()` ([#1357](https://github.com/finos/rune-dsl/pull/1357)).